### PR TITLE
bumping Vulkan version for instance creation to 1.1

### DIFF
--- a/piet-gpu-hal/src/vulkan.rs
+++ b/piet-gpu-hal/src/vulkan.rs
@@ -161,7 +161,7 @@ impl VkInstance {
                             .application_name(&app_name)
                             .application_version(0)
                             .engine_name(&app_name)
-                            .api_version(vk::make_version(1, 0, 0)),
+                            .api_version(vk::make_version(1, 1, 0)),
                     )
                     .enabled_layer_names(&layers)
                     .enabled_extension_names(&exts),


### PR DESCRIPTION
The prefix examples requires subgroups, which are not available in Vulkan 1.0, thus 1.1 should be required.
