### PR TITLE
Fix linewidth transformations

### DIFF
--- a/piet-gpu/shader/elements.comp
+++ b/piet-gpu/shader/elements.comp
@@ -373,7 +373,7 @@ void main() {
             anno_stroke.rgba_color = stroke.rgba_color;
             vec2 lw = get_linewidth(st);
             anno_stroke.bbox = st.bbox + vec4(-lw, lw);
-            anno_stroke.linewidth = st.linewidth * sqrt(st.mat.x * st.mat.w - st.mat.y * st.mat.z);
+            anno_stroke.linewidth = st.linewidth * sqrt(abs(st.mat.x * st.mat.w - st.mat.y * st.mat.z));
             AnnotatedRef out_ref = AnnotatedRef((st.path_count - 1) * Annotated_size);
             Annotated_Stroke_write(out_ref, anno_stroke);
             break;


### PR DESCRIPTION
The transformation determinant is signed, but we're only interested in
the absolute scale for transforming linewidths.