### PR TITLE
Minor cleanups

### DIFF
--- a/piet-gpu-hal/examples/collatz.rs
+++ b/piet-gpu-hal/examples/collatz.rs
@@ -24,6 +24,7 @@ fn main() {
         cmd_buf.write_timestamp(&query_pool, 0);
         cmd_buf.dispatch(&pipeline, &descriptor_set, (256, 1, 1));
         cmd_buf.write_timestamp(&query_pool, 1);
+        cmd_buf.host_barrier();
         cmd_buf.finish();
         device
             .run_cmd_buf(&cmd_buf, &[], &[], Some(&fence))

--- a/piet-gpu-hal/src/lib.rs
+++ b/piet-gpu-hal/src/lib.rs
@@ -100,7 +100,20 @@ pub trait CmdBuf<D: Device> {
         size: (u32, u32, u32),
     );
 
+    /// Insert an execution and memory barrier.
+    ///
+    /// Compute kernels (and other actions) after this barrier may read from buffers
+    /// that were written before this barrier.
     unsafe fn memory_barrier(&mut self);
+
+    /// Insert a barrier for host access to buffers.
+    ///
+    /// The host may read buffers written before this barrier, after the fence for
+    /// the command buffer is signaled.
+    ///
+    /// See http://themaister.net/blog/2019/08/14/yet-another-blog-explaining-vulkan-synchronization/
+    /// ("Host memory reads") for an explanation of this barrier.
+    unsafe fn host_barrier(&mut self);
 
     unsafe fn image_barrier(
         &mut self,
@@ -119,6 +132,8 @@ pub trait CmdBuf<D: Device> {
     unsafe fn copy_buffer(&self, src: &D::Buffer, dst: &D::Buffer);
 
     unsafe fn copy_image_to_buffer(&self, src: &D::Image, dst: &D::Buffer);
+
+    unsafe fn copy_buffer_to_image(&self, src: &D::Buffer, dst: &D::Image);
 
     // low portability, dx12 doesn't support it natively
     unsafe fn blit_image(&self, src: &D::Image, dst: &D::Image);

--- a/piet-gpu/bin/cli.rs
+++ b/piet-gpu/bin/cli.rs
@@ -225,6 +225,7 @@ fn main() -> Result<(), Error> {
         cmd_buf.begin();
         renderer.record(&mut cmd_buf, &query_pool);
         cmd_buf.copy_image_to_buffer(&renderer.image_dev, &image_buf);
+        cmd_buf.host_barrier();
         cmd_buf.finish();
         let start = std::time::Instant::now();
         device.run_cmd_buf(&cmd_buf, &[], &[], Some(&fence))?;


### PR DESCRIPTION
Mostly cleaning up some comments. Also adds host barrier and a command
to copy a buffer to an image (in preparation for images, see #38).