### PR TITLE
Always close fill paths, fix #68

### DIFF
--- a/piet-gpu/src/render_ctx.rs
+++ b/piet-gpu/src/render_ctx.rs
@@ -303,6 +303,21 @@ impl PietGpuRenderContext {
     }
 
     fn encode_path(&mut self, path: impl Iterator<Item = PathEl>, is_fill: bool) {
+        if is_fill {
+            self.encode_path_inner(path.flat_map(|el| {
+                match el {
+                    PathEl::MoveTo(..) => {
+                        Some(PathEl::ClosePath)
+                    }
+                    _ => None
+                }.into_iter().chain(Some(el))
+            }).chain(Some(PathEl::ClosePath)), is_fill)
+        } else {
+            self.encode_path_inner(path, is_fill)
+        }
+    }
+
+    fn encode_path_inner(&mut self, path: impl Iterator<Item = PathEl>, is_fill: bool) {
         let flatten = false;
         if flatten {
             let mut start_pt = None;


### PR DESCRIPTION
![rendering](https://user-images.githubusercontent.com/12389383/111268985-5d51cb00-8671-11eb-9284-5d883e914ecc.png)

There are still a few minor glitches visible (even after applying #72), so we should revisit them at a later time. For now, I think this is enough for closing the issue. The glitches are primarily around the edge of the crossing-like structures.

Close #68 
Close #74