### PR TITLE
Expand runtime query of GPU capabilities

### DIFF
--- a/piet-gpu-hal/src/lib.rs
+++ b/piet-gpu-hal/src/lib.rs
@@ -29,6 +29,29 @@ pub enum SamplerParams {
     Linear,
 }
 
+#[derive(Clone, Debug)]
+/// Information about the GPU.
+pub struct GpuInfo {
+    /// The GPU supports descriptor indexing.
+    pub has_descriptor_indexing: bool,
+    /// The GPU supports subgroups.
+    ///
+    /// Right now, this just checks for basic subgroup capability (as
+    /// required in Vulkan 1.1), and we should have finer grained
+    /// queries for shuffles, etc.
+    pub has_subgroups: bool,
+    /// Info about subgroup size control, if available.
+    pub subgroup_size: Option<SubgroupSize>,
+    /// The GPU supports a real, grown-ass memory model.
+    pub has_memory_model: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct SubgroupSize {
+    min: u32,
+    max: u32,
+}
+
 pub trait Device: Sized {
     type Buffer: 'static;
     type Image;
@@ -42,6 +65,12 @@ pub trait Device: Sized {
     type PipelineBuilder: PipelineBuilder<Self>;
     type DescriptorSetBuilder: DescriptorSetBuilder<Self>;
     type Sampler;
+
+    /// Query the GPU info.
+    ///
+    /// This method may be expensive, so the hub should call it once and retain
+    /// the info.
+    fn query_gpu_info(&self) -> GpuInfo;
 
     fn create_buffer(&self, size: u64, mem_flags: Self::MemFlags) -> Result<Self::Buffer, Error>;
 

--- a/piet-gpu/src/lib.rs
+++ b/piet-gpu/src/lib.rs
@@ -128,11 +128,20 @@ fn render_clip_test(rc: &mut impl RenderContext) {
 #[allow(unused)]
 fn render_alpha_test(rc: &mut impl RenderContext) {
     // Alpha compositing tests.
-    rc.fill(diamond(Point::new(1024.0, 100.0)), &Color::Rgba32(0xff0000ff));
-    rc.fill(diamond(Point::new(1024.0, 125.0)), &Color::Rgba32(0x00ff0080));
+    rc.fill(
+        diamond(Point::new(1024.0, 100.0)),
+        &Color::Rgba32(0xff0000ff),
+    );
+    rc.fill(
+        diamond(Point::new(1024.0, 125.0)),
+        &Color::Rgba32(0x00ff0080),
+    );
     rc.save();
     rc.clip(diamond(Point::new(1024.0, 150.0)));
-    rc.fill(diamond(Point::new(1024.0, 175.0)), &Color::Rgba32(0x0000ff80));
+    rc.fill(
+        diamond(Point::new(1024.0, 175.0)),
+        &Color::Rgba32(0x0000ff80),
+    );
     rc.restore();
 }
 
@@ -325,7 +334,7 @@ impl Renderer {
 
         let bg_image = Self::make_test_bg_image(&session);
 
-        let k4_code = if session.has_descriptor_indexing() {
+        let k4_code = if session.gpu_info().has_descriptor_indexing {
             &include_bytes!("../shader/kernel4_idx.spv")[..]
         } else {
             println!("doing non-indexed k4");

--- a/piet-gpu/src/render_ctx.rs
+++ b/piet-gpu/src/render_ctx.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, ops::RangeBounds};
 
 use piet::{
-    HitTestPosition,
-    kurbo::{Affine, Insets, PathEl, Point, Rect, Shape, Size}, TextAttribute, TextStorage,
+    kurbo::{Affine, Insets, PathEl, Point, Rect, Shape, Size},
+    HitTestPosition, TextAttribute, TextStorage,
 };
 use piet::{
     Color, Error, FixedGradient, FontFamily, HitTestPoint, ImageFormat, InterpolationMode,
@@ -143,7 +143,12 @@ impl RenderContext for PietGpuRenderContext {
         //
         // See also http://ssp.impulsetrain.com/gamma-premult.html.
         let (r, g, b, a) = color.as_rgba();
-        let premul = Color::rgba(to_srgb(from_srgb(r) * a), to_srgb(from_srgb(g) * a), to_srgb(from_srgb(b) * a), a);
+        let premul = Color::rgba(
+            to_srgb(from_srgb(r) * a),
+            to_srgb(from_srgb(g) * a),
+            to_srgb(from_srgb(b) * a),
+            a,
+        );
         PietGpuBrush::Solid(premul.as_rgba_u32())
     }
 
@@ -182,7 +187,8 @@ impl RenderContext for PietGpuRenderContext {
         _brush: &impl IntoBrush<Self>,
         _width: f64,
         _style: &StrokeStyle,
-    ) {}
+    ) {
+    }
 
     fn fill(&mut self, shape: impl Shape, brush: &impl IntoBrush<Self>) {
         let brush = brush.make_brush(self, || shape.bounding_box()).into_owned();
@@ -284,7 +290,8 @@ impl RenderContext for PietGpuRenderContext {
         _image: &Self::Image,
         _rect: impl Into<Rect>,
         _interp: InterpolationMode,
-    ) {}
+    ) {
+    }
 
     fn draw_image_area(
         &mut self,
@@ -292,7 +299,8 @@ impl RenderContext for PietGpuRenderContext {
         _src_rect: impl Into<Rect>,
         _dst_rect: impl Into<Rect>,
         _interp: InterpolationMode,
-    ) {}
+    ) {
+    }
 
     fn blurred_rect(&mut self, _rect: Rect, _blur_radius: f64, _brush: &impl IntoBrush<Self>) {}
 
@@ -323,7 +331,7 @@ impl PietGpuRenderContext {
         self.pathseg_count += 1;
     }
 
-    fn encode_path(&mut self, path: impl Iterator<Item=PathEl>, is_fill: bool) {
+    fn encode_path(&mut self, path: impl Iterator<Item = PathEl>, is_fill: bool) {
         if is_fill {
             self.encode_path_inner(
                 path.flat_map(|el| {
@@ -341,7 +349,7 @@ impl PietGpuRenderContext {
         }
     }
 
-    fn encode_path_inner(&mut self, path: impl Iterator<Item=PathEl>) {
+    fn encode_path_inner(&mut self, path: impl Iterator<Item = PathEl>) {
         let flatten = false;
         if flatten {
             let mut start_pt = None;


### PR DESCRIPTION
Test whether the GPU supports subgroups (including size control) and
memory model.

This patch does all the ceremony needed for runtime query, including
testing the Vulkan version and only probing the extensions when
available. Thus, it should work fine on older devices (not yet tested).

The reporting of capabilities follows Vulkan concepts, but is not
particularly Vulkan-specific.