### PR TITLE
Make canvas size dynamic

### DIFF
--- a/piet-gpu/bin/cli.rs
+++ b/piet-gpu/bin/cli.rs
@@ -6,7 +6,10 @@ use clap::{App, Arg};
 
 use piet_gpu_hal::{BufferUsage, Error, Instance, Session};
 
-use piet_gpu::{render_scene, render_svg, PietGpuRenderContext, Renderer, HEIGHT, WIDTH};
+use piet_gpu::{render_scene, render_svg, PietGpuRenderContext, Renderer};
+
+const WIDTH: usize = 2048;
+const HEIGHT: usize = 1536;
 
 #[allow(unused)]
 fn dump_scene(buf: &[u8]) {
@@ -245,7 +248,7 @@ fn main() -> Result<(), Error> {
             render_scene(&mut ctx);
         }
 
-        let mut renderer = Renderer::new(&session)?;
+        let mut renderer = Renderer::new(&session, WIDTH, HEIGHT)?;
         renderer.upload_render_ctx(&mut ctx)?;
         let image_usage = BufferUsage::MAP_READ | BufferUsage::COPY_DST;
         let image_buf = session.create_buffer((WIDTH * HEIGHT * 4) as u64, image_usage)?;

--- a/piet-gpu/bin/winit.rs
+++ b/piet-gpu/bin/winit.rs
@@ -1,6 +1,6 @@
 use piet_gpu_hal::{Error, ImageLayout, Instance, Session, SubmittedCmdBuf};
 
-use piet_gpu::{render_scene, PietGpuRenderContext, Renderer, HEIGHT, WIDTH, render_svg};
+use piet_gpu::{render_scene, render_svg, PietGpuRenderContext, Renderer};
 
 use clap::{App, Arg};
 
@@ -11,6 +11,9 @@ use winit::{
 };
 
 const NUM_FRAMES: usize = 2;
+
+const WIDTH: usize = 2048;
+const HEIGHT: usize = 1536;
 
 fn main() -> Result<(), Error> {
     let matches = App::new("piet-gpu test")
@@ -62,7 +65,7 @@ fn main() -> Result<(), Error> {
             render_scene(&mut ctx);
         }
 
-        let mut renderer = Renderer::new(&session)?;
+        let mut renderer = Renderer::new(&session, WIDTH, HEIGHT)?;
         renderer.upload_render_ctx(&mut ctx)?;
 
         let mut submitted: Option<SubmittedCmdBuf> = None;

--- a/piet-gpu/src/render_ctx.rs
+++ b/piet-gpu/src/render_ctx.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, ops::RangeBounds};
 
+use crate::MAX_BLEND_STACK;
 use piet::{
     kurbo::{Affine, Insets, PathEl, Point, Rect, Shape, Size},
     HitTestPosition, TextAttribute, TextStorage,
@@ -8,7 +9,6 @@ use piet::{
     Color, Error, FixedGradient, FontFamily, HitTestPoint, ImageFormat, InterpolationMode,
     IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
-use crate::MAX_BLEND_STACK;
 
 use piet_gpu_types::encoder::{Encode, Encoder};
 use piet_gpu_types::scene::{


### PR DESCRIPTION
Instead of hard-coding the canvas size, pass it in on renderer creation.

It's still fixed on desktop, but on Android it gets the size from the
window.