### PR TITLE
Upgrade to Ash 0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,18 +44,18 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ash"
-version = "0.31.0"
+version = "0.33.3+1.2.191"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69a8137596e84c22d57f3da1b5de1d4230b1742a710091c85f4d7ce50f00f38"
+checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
 dependencies = [
- "libloading",
+ "libloading 0.7.1",
 ]
 
 [[package]]
 name = "ash-window"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905c4ca25f752e7ab3c3e8f2882625f876e4c3ea5feffbc83f81d697e043afd6"
+checksum = "12f91ce4c6be1a2ba99d3d6cd57d5bae9ac6d6f903b5ae53d6b1dee2edf872af"
 dependencies = [
  "ash",
  "raw-window-handle",
@@ -348,7 +348,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76"
 dependencies = [
- "libloading",
+ "libloading 0.6.5",
 ]
 
 [[package]]
@@ -492,6 +492,16 @@ name = "libloading"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1090080fe06ec2648d0da3881d9453d97e71a45f00eb179af7fdd7e3f686fdb0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "libloading"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",

--- a/piet-gpu-hal/Cargo.toml
+++ b/piet-gpu-hal/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-ash = "0.31"
-ash-window = "0.5"
+ash = "0.33"
+ash-window = "0.7"
 raw-window-handle = "0.3"
 bitflags = "1.2.1"
 smallvec = "1.6.1"

--- a/piet-gpu/src/text.rs
+++ b/piet-gpu/src/text.rs
@@ -172,11 +172,8 @@ impl PietGpuTextLayout {
 
     pub(crate) fn draw_text(&self, ctx: &mut PietGpuRenderContext, pos: Point) {
         let mut scale_ctx = ScaleContext::new();
-        let scaler = scale_ctx.builder(self.font.font_ref).size(2048.)
-            .build();
-        let mut tc = TextRenderCtx {
-            scaler,
-        };
+        let scaler = scale_ctx.builder(self.font.font_ref).size(2048.).build();
+        let mut tc = TextRenderCtx { scaler };
         // Should we use ppem from font, or let swash scale?
         const DEFAULT_UPEM: u16 = 2048;
         let scale = self.size as f32 / DEFAULT_UPEM as f32;


### PR DESCRIPTION
This was motivated by experiments with the Vulkan memory model. To use
that, we actually need to explicitly enable the relevant feature on
device creation time. That's a lot easier to do now that push_next works
on the structs in that chain. This PR doesn't do that though, it only
upgrades the dependency and cleans up deprecations.