### PR TITLE
piet-gpu, hal: Add Vulkan debug markers

### DIFF
--- a/piet-gpu-hal/src/backend.rs
+++ b/piet-gpu-hal/src/backend.rs
@@ -218,6 +218,12 @@ pub trait CmdBuf<D: Device> {
     /// Prepare the timestamps for reading. This isn't required on Vulkan but
     /// is required on (at least) DX12.
     unsafe fn finish_timestamps(&mut self, _pool: &D::QueryPool) {}
+
+    /// Begin a labeled section for debugging and profiling purposes.
+    unsafe fn begin_debug_label(&mut self, label: &str) {}
+
+    /// End a section opened by `begin_debug_label`.
+    unsafe fn end_debug_label(&mut self) {}
 }
 
 /// A builder for descriptor sets with more complex layouts.

--- a/piet-gpu-hal/src/hub.rs
+++ b/piet-gpu-hal/src/hub.rs
@@ -569,6 +569,16 @@ impl CmdBuf {
         self.cmd_buf().finish_timestamps(pool);
     }
 
+    /// Begin a labeled section for debugging and profiling purposes.
+    pub unsafe fn begin_debug_label(&mut self, label: &str) {
+        self.cmd_buf().begin_debug_label(label);
+    }
+
+    /// End a section opened by `begin_debug_label`.
+    pub unsafe fn end_debug_label(&mut self) {
+        self.cmd_buf().end_debug_label();
+    }
+
     /// Make sure the resource lives until the command buffer completes.
     ///
     /// The submitted command buffer will hold this reference until the corresponding

--- a/piet-gpu-hal/src/mux.rs
+++ b/piet-gpu-hal/src/mux.rs
@@ -734,6 +734,22 @@ impl CmdBuf {
             CmdBuf::Mtl(c) => c.finish_timestamps(pool.mtl()),
         }
     }
+
+    pub unsafe fn begin_debug_label(&mut self, label: &str) {
+        mux_match! { self;
+            CmdBuf::Vk(c) => c.begin_debug_label(label),
+            CmdBuf::Dx12(c) => c.begin_debug_label(label),
+            CmdBuf::Mtl(c) => c.begin_debug_label(label),
+        }
+    }
+
+    pub unsafe fn end_debug_label(&mut self) {
+        mux_match! { self;
+            CmdBuf::Vk(c) => c.end_debug_label(),
+            CmdBuf::Dx12(c) => c.end_debug_label(),
+            CmdBuf::Mtl(c) => c.end_debug_label(),
+        }
+    }
 }
 
 impl Buffer {


### PR DESCRIPTION
Other backends are left as stub for now.

Makes it easier to identify stages within Radeon GPU Profiler and others.

The markers are only enabled for `debug-assertions` builds for now, we probably should revisit this in the future.