### PR TITLE
Add kurbo conversions to scene API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "ash"
 version = "0.33.3+1.2.191"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,7 +602,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cb54cd28cb3d2e964d9444ca185676a94fd9b7cce5f02b22c717947ed8e9a2"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a53776d271cfb873b17c618af0298445c88afc52837f3e948fa3fafd131f449"
+dependencies = [
+ "arrayvec 0.7.2",
 ]
 
 [[package]]
@@ -755,8 +770,7 @@ dependencies = [
 [[package]]
 name = "moscato"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8372f6cdc8b2c431750a9c4edbc8d9c511ef1a68472aaa02500493414a407c64"
+source = "git+https://github.com/dfrg/pinot#59db153ff83420449a909dfaace18466bddbf814"
 dependencies = [
  "pinot",
 ]
@@ -954,7 +968,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00543608fb5ee6063f5ff1259246ae23073c1a5e413e643d0469da3d4b7b4de"
 dependencies = [
- "kurbo",
+ "kurbo 0.7.1",
  "unic-bidi",
 ]
 
@@ -1012,7 +1026,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "clap",
- "kurbo",
+ "kurbo 0.7.1",
  "piet-gpu",
  "piet-gpu-hal",
  "rand",
@@ -1031,8 +1045,8 @@ name = "piet-scene"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "kurbo 0.8.3",
  "moscato",
- "pinot",
  "smallvec",
 ]
 

--- a/piet-scene/Cargo.toml
+++ b/piet-scene/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [dependencies]
 bytemuck = { version = "1.7.2", features = ["derive"] }
 smallvec = "1.8.0"
-pinot = "0.1.5"
-moscato = "0.1.2"
+moscato = { git = "https://github.com/dfrg/pinot" }
+kurbo = { version = "0.8.3", optional = true }

--- a/piet-scene/src/glyph/mod.rs
+++ b/piet-scene/src/glyph/mod.rs
@@ -14,7 +14,7 @@
 //
 // Also licensed under MIT license, at your choice.
 
-pub use pinot;
+pub use moscato::pinot;
 
 use crate::brush::{Brush, Color};
 use crate::geometry::Affine;

--- a/piet-scene/src/lib.rs
+++ b/piet-scene/src/lib.rs
@@ -28,9 +28,10 @@ mod kurbo_conv {
     use super::geometry::{Affine, Point, Rect};
     use super::path::Element;
 
-    impl From<kurbo::Point> for Point {
-        fn from(p: kurbo::Point) -> Self {
-            Self::new(p.x as f32, p.y as f32)
+    impl Point {
+        /// Creates a new point from the equivalent kurbo type.
+        pub fn from_kurbo(point: kurbo::Point) -> Self {
+            Self::new(point.x as f32, point.y as f32)
         }
     }
 
@@ -40,9 +41,10 @@ mod kurbo_conv {
         }
     }
 
-    impl From<kurbo::Affine> for Affine {
-        fn from(a: kurbo::Affine) -> Self {
-            let c = a.as_coeffs();
+    impl Affine {
+        /// Creates a new affine transformation from the equivalent kurbo type.
+        pub fn from_kurbo(affine: kurbo::Affine) -> Self {
+            let c = affine.as_coeffs();
             Self {
                 xx: c[0] as f32,
                 yx: c[1] as f32,
@@ -67,11 +69,12 @@ mod kurbo_conv {
         }
     }
 
-    impl From<kurbo::Rect> for Rect {
-        fn from(r: kurbo::Rect) -> Self {
+    impl Rect {
+        /// Creates a new rectangle from the equivalent kurbo type.
+        pub fn from_kurbo(rect: kurbo::Rect) -> Self {
             Self {
-                min: Point::new(r.x0 as f32, r.y0 as f32),
-                max: Point::new(r.x1 as f32, r.y1 as f32),
+                min: Point::new(rect.x0 as f32, rect.y0 as f32),
+                max: Point::new(rect.x1 as f32, rect.y1 as f32),
             }
         }
     }
@@ -95,6 +98,23 @@ mod kurbo_conv {
                 LineTo(p0) => Self::LineTo(p0.into()),
                 QuadTo(p0, p1) => Self::QuadTo(p0.into(), p1.into()),
                 CurveTo(p0, p1, p2) => Self::CurveTo(p0.into(), p1.into(), p2.into()),
+                ClosePath => Self::Close,
+            }
+        }
+    }
+
+    impl Element {
+        /// Creates a new path element from the equivalent kurbo type.
+        pub fn from_kurbo(el: kurbo::PathEl) -> Self {
+            use kurbo::PathEl::*;
+            use Point::from_kurbo;
+            match e {
+                MoveTo(p0) => Self::MoveTo(from_kurbo(p0)),
+                LineTo(p0) => Self::LineTo(from_kurbo(p0)),
+                QuadTo(p0, p1) => Self::QuadTo(from_kurbo(p0), from_kurbo(p1)),
+                CurveTo(p0, p1, p2) => {
+                    Self::CurveTo(from_kurbo(p0), from_kurbo(p1), from_kurbo(p2))
+                }
                 ClosePath => Self::Close,
             }
         }

--- a/piet-scene/src/lib.rs
+++ b/piet-scene/src/lib.rs
@@ -90,19 +90,6 @@ mod kurbo_conv {
         }
     }
 
-    impl From<kurbo::PathEl> for Element {
-        fn from(e: kurbo::PathEl) -> Self {
-            use kurbo::PathEl::*;
-            match e {
-                MoveTo(p0) => Self::MoveTo(p0.into()),
-                LineTo(p0) => Self::LineTo(p0.into()),
-                QuadTo(p0, p1) => Self::QuadTo(p0.into(), p1.into()),
-                CurveTo(p0, p1, p2) => Self::CurveTo(p0.into(), p1.into(), p2.into()),
-                ClosePath => Self::Close,
-            }
-        }
-    }
-
     impl Element {
         /// Creates a new path element from the equivalent kurbo type.
         pub fn from_kurbo(el: kurbo::PathEl) -> Self {

--- a/piet-scene/src/lib.rs
+++ b/piet-scene/src/lib.rs
@@ -20,3 +20,96 @@ pub mod glyph;
 pub mod path;
 pub mod resource;
 pub mod scene;
+
+/// Implement conversions to and from Kurbo types when the `kurbo` feature is
+/// enabled.
+#[cfg(feature = "kurbo")]
+mod kurbo_conv {
+    use super::geometry::{Affine, Point, Rect};
+    use super::path::Element;
+
+    impl From<kurbo::Point> for Point {
+        fn from(p: kurbo::Point) -> Self {
+            Self::new(p.x as f32, p.y as f32)
+        }
+    }
+
+    impl From<Point> for kurbo::Point {
+        fn from(p: Point) -> kurbo::Point {
+            Self::new(p.x as f64, p.y as f64)
+        }
+    }
+
+    impl From<kurbo::Affine> for Affine {
+        fn from(a: kurbo::Affine) -> Self {
+            let c = a.as_coeffs();
+            Self {
+                xx: c[0] as f32,
+                yx: c[1] as f32,
+                xy: c[2] as f32,
+                yy: c[3] as f32,
+                dx: c[4] as f32,
+                dy: c[5] as f32,
+            }
+        }
+    }
+
+    impl From<Affine> for kurbo::Affine {
+        fn from(a: Affine) -> Self {
+            Self::new([
+                a.xx as f64,
+                a.yx as f64,
+                a.yx as f64,
+                a.yy as f64,
+                a.dx as f64,
+                a.dy as f64,
+            ])
+        }
+    }
+
+    impl From<kurbo::Rect> for Rect {
+        fn from(r: kurbo::Rect) -> Self {
+            Self {
+                min: Point::new(r.x0 as f32, r.y0 as f32),
+                max: Point::new(r.x1 as f32, r.y1 as f32),
+            }
+        }
+    }
+
+    impl From<Rect> for kurbo::Rect {
+        fn from(r: Rect) -> Self {
+            Self {
+                x0: r.min.x as f64,
+                y0: r.min.y as f64,
+                x1: r.max.x as f64,
+                y1: r.max.y as f64,
+            }
+        }
+    }
+
+    impl From<kurbo::PathEl> for Element {
+        fn from(e: kurbo::PathEl) -> Self {
+            use kurbo::PathEl::*;
+            match e {
+                MoveTo(p0) => Self::MoveTo(p0.into()),
+                LineTo(p0) => Self::LineTo(p0.into()),
+                QuadTo(p0, p1) => Self::QuadTo(p0.into(), p1.into()),
+                CurveTo(p0, p1, p2) => Self::CurveTo(p0.into(), p1.into(), p2.into()),
+                ClosePath => Self::Close,
+            }
+        }
+    }
+
+    impl From<Element> for kurbo::PathEl {
+        fn from(e: Element) -> Self {
+            use Element::*;
+            match e {
+                MoveTo(p0) => Self::MoveTo(p0.into()),
+                LineTo(p0) => Self::LineTo(p0.into()),
+                QuadTo(p0, p1) => Self::QuadTo(p0.into(), p1.into()),
+                CurveTo(p0, p1, p2) => Self::CurveTo(p0.into(), p1.into(), p2.into()),
+                Close => Self::ClosePath,
+            }
+        }
+    }
+}

--- a/piet-scene/src/scene/blend.rs
+++ b/piet-scene/src/scene/blend.rs
@@ -34,6 +34,8 @@ pub enum Mix {
     Saturation = 13,
     Color = 14,
     Luminosity = 15,
+    // Clip is the same as normal, but doesn't always push a blend group.
+    Clip = 128,
 }
 
 /// Defines the layer composition function for a blend operation.
@@ -76,7 +78,7 @@ impl Blend {
 impl Default for Blend {
     fn default() -> Self {
         Self {
-            mix: Mix::Normal,
+            mix: Mix::Clip,
             compose: Compose::SrcOver,
         }
     }

--- a/piet-scene/src/scene/blend.rs
+++ b/piet-scene/src/scene/blend.rs
@@ -53,8 +53,7 @@ pub enum Compose {
     DestAtop = 10,
     Xor = 11,
     Plus = 12,
-    PlusDarker = 13,
-    PlusLighter = 14,
+    PlusLighter = 13,
 }
 
 /// Blend mode consisting of mixing and composition functions.

--- a/piet-scene/src/scene/builder.rs
+++ b/piet-scene/src/scene/builder.rs
@@ -23,12 +23,14 @@ use core::borrow::Borrow;
 
 const MAX_BLEND_STACK: usize = 256;
 
-/// Creates a new builder for constructing a scene.
+/// Creates a new builder for filling a scene. Any current content in the scene
+/// will be cleared.
 pub fn build_scene<'a>(scene: &'a mut Scene, rcx: &'a mut ResourceContext) -> Builder<'a> {
     Builder::new(&mut scene.data, ResourceData::Scene(rcx))
 }
 
-/// Creates a new builder for construction a scene fragment.
+/// Creates a new builder for filling a scene fragment. Any current content in
+/// the fragment will be cleared.
 pub fn build_fragment<'a>(fragment: &'a mut Fragment) -> Builder<'a> {
     Builder::new(
         &mut fragment.data,
@@ -62,8 +64,7 @@ impl<'a> Builder<'a> {
     }
 
     /// Pushes a transform matrix onto the stack.
-    pub fn push_transform(&mut self, transform: impl Into<Affine>) {
-        let transform = transform.into();
+    pub fn push_transform(&mut self, transform: Affine) {
         self.transform(transform);
         self.transforms.push(transform);
     }

--- a/piet-scene/src/scene/builder.rs
+++ b/piet-scene/src/scene/builder.rs
@@ -24,8 +24,8 @@ use core::borrow::Borrow;
 const MAX_BLEND_STACK: usize = 256;
 
 /// Creates a new builder for constructing a scene.
-pub fn build_scene<'a>(scene: &'a mut Scene, resources: &'a mut ResourceContext) -> Builder<'a> {
-    Builder::new(&mut scene.data, ResourceData::Scene(resources))
+pub fn build_scene<'a>(scene: &'a mut Scene, rcx: &'a mut ResourceContext) -> Builder<'a> {
+    Builder::new(&mut scene.data, ResourceData::Scene(rcx))
 }
 
 /// Creates a new builder for construction a scene fragment.
@@ -62,7 +62,8 @@ impl<'a> Builder<'a> {
     }
 
     /// Pushes a transform matrix onto the stack.
-    pub fn push_transform(&mut self, transform: Affine) {
+    pub fn push_transform(&mut self, transform: impl Into<Affine>) {
+        let transform = transform.into();
         self.transform(transform);
         self.transforms.push(transform);
     }

--- a/piet-scene/src/scene/mod.rs
+++ b/piet-scene/src/scene/mod.rs
@@ -23,11 +23,13 @@ pub use builder::{build_fragment, build_scene, Builder};
 pub use style::*;
 
 use super::brush::*;
-use super::geometry::{Affine, Point, Rect};
+use super::geometry::{Affine, Point};
 use super::path::Element;
+use super::resource::ResourceContext;
 
 use core::ops::Range;
 
+/// Raw data streams describing an encoded scene.
 #[derive(Default)]
 pub struct SceneData {
     pub transform_stream: Vec<Affine>,
@@ -83,6 +85,13 @@ pub struct Scene {
 }
 
 impl Scene {
+    /// Creates a new builder for filling the scene. Any current content in
+    /// the scene is cleared.
+    pub fn build<'a>(&'a mut self, rcx: &'a mut ResourceContext) -> Builder<'a> {
+        build_scene(self, rcx)
+    }
+
+    /// Returns the raw encoded scene data streams.
     pub fn data(&self) -> &SceneData {
         &self.data
     }
@@ -96,8 +105,16 @@ pub struct Fragment {
 }
 
 impl Fragment {
+    /// Returns the underlying stream of points that defined all encoded path
+    /// segments.
     pub fn points(&self) -> &[Point] {
         bytemuck::cast_slice(&self.data.pathseg_stream)
+    }
+
+    /// Creates a new builder for filling the fragment. Any current content in
+    /// the fragment is cleared.
+    pub fn build<'a>(&'a mut self) -> Builder<'a> {
+        build_fragment(self)
     }
 }
 

--- a/piet-scene/src/scene/mod.rs
+++ b/piet-scene/src/scene/mod.rs
@@ -25,7 +25,6 @@ pub use style::*;
 use super::brush::*;
 use super::geometry::{Affine, Point};
 use super::path::Element;
-use super::resource::ResourceContext;
 
 use core::ops::Range;
 
@@ -85,12 +84,6 @@ pub struct Scene {
 }
 
 impl Scene {
-    /// Creates a new builder for filling the scene. Any current content in
-    /// the scene is cleared.
-    pub fn build<'a>(&'a mut self, rcx: &'a mut ResourceContext) -> Builder<'a> {
-        build_scene(self, rcx)
-    }
-
     /// Returns the raw encoded scene data streams.
     pub fn data(&self) -> &SceneData {
         &self.data
@@ -109,12 +102,6 @@ impl Fragment {
     /// segments.
     pub fn points(&self) -> &[Point] {
         bytemuck::cast_slice(&self.data.pathseg_stream)
-    }
-
-    /// Creates a new builder for filling the fragment. Any current content in
-    /// the fragment is cleared.
-    pub fn build<'a>(&'a mut self) -> Builder<'a> {
-        build_fragment(self)
     }
 }
 


### PR DESCRIPTION
This is a small follow up PR to #168 that adds an optional dependency on kurbo to the scene crate along with the associated two-way conversions between common types when the feature is enabled.

There is a question of which version of kurbo we want to depend on. This currently uses 0.8.3 which is the latest available on crates.io while piet-gpu inherits version 0.7.0 from its older piet dependency. 