### PR TITLE
Add HAL methods to update descriptor set

### DIFF
--- a/piet-gpu-hal/src/backend.rs
+++ b/piet-gpu-hal/src/backend.rs
@@ -98,6 +98,36 @@ pub trait Device: Sized {
         builder.build(self, pipeline)
     }
 
+    /// Update a descriptor in a descriptor set.
+    ///
+    /// The index is the same as the binding number in Vulkan.
+    ///
+    /// # Safety
+    ///
+    /// The descriptor set must not be used in any in-flight command buffer. The index must be valid.
+    /// The resource type must match that at descriptor set creation time.
+    unsafe fn update_buffer_descriptor(
+        &self,
+        ds: &mut Self::DescriptorSet,
+        index: u32,
+        buf: &Self::Buffer,
+    );
+
+    /// Update a descriptor in a descriptor set.
+    ///
+    /// The index is the same as the binding number in Vulkan.
+    ///
+    /// # Safety
+    ///
+    /// The descriptor set must not be used in any in-flight command buffer. The index must be valid.
+    /// The resource type must match that at descriptor set creation time.
+    unsafe fn update_image_descriptor(
+        &self,
+        ds: &mut Self::DescriptorSet,
+        index: u32,
+        image: &Self::Image,
+    );
+
     fn create_cmd_buf(&self) -> Result<Self::CmdBuf, Error>;
 
     /// If the command buffer was submitted, it must complete before this is called.

--- a/piet-gpu-hal/src/dx12/wrappers.rs
+++ b/piet-gpu-hal/src/dx12/wrappers.rs
@@ -405,6 +405,16 @@ impl Device {
         );
     }
 
+    pub unsafe fn copy_one_descriptor(
+        &self,
+        dst: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
+        src: d3d12::D3D12_CPU_DESCRIPTOR_HANDLE,
+        descriptor_heap_type: d3d12::D3D12_DESCRIPTOR_HEAP_TYPE,
+    ) {
+        self.0
+            .CopyDescriptorsSimple(1, dst, src, descriptor_heap_type);
+    }
+
     pub unsafe fn create_compute_pipeline_state(
         &self,
         compute_pipeline_desc: &d3d12::D3D12_COMPUTE_PIPELINE_STATE_DESC,

--- a/piet-gpu-hal/src/hub.rs
+++ b/piet-gpu-hal/src/hub.rs
@@ -366,6 +366,30 @@ impl Session {
         DescriptorSetBuilder(self.0.device.descriptor_set_builder())
     }
 
+    /// Update a buffer in a descriptor set.
+    pub unsafe fn update_buffer_descriptor(
+        &self,
+        ds: &mut DescriptorSet,
+        index: u32,
+        buffer: &Buffer,
+    ) {
+        self.0
+            .device
+            .update_buffer_descriptor(ds, index, &buffer.0.buffer)
+    }
+
+    /// Update an image in a descriptor set.
+    pub unsafe fn update_image_descriptor(
+        &self,
+        ds: &mut DescriptorSet,
+        index: u32,
+        image: &Image,
+    ) {
+        self.0
+            .device
+            .update_image_descriptor(ds, index, &image.0.image)
+    }
+
     /// Create a query pool for timestamp queries.
     pub fn create_query_pool(&self, n_queries: u32) -> Result<QueryPool, Error> {
         self.0.device.create_query_pool(n_queries)

--- a/piet-gpu-hal/src/metal.rs
+++ b/piet-gpu-hal/src/metal.rs
@@ -385,6 +385,24 @@ impl crate::backend::Device for MtlDevice {
         DescriptorSetBuilder::default()
     }
 
+    unsafe fn update_buffer_descriptor(
+        &self,
+        ds: &mut Self::DescriptorSet,
+        index: u32,
+        buf: &Self::Buffer,
+    ) {
+        ds.buffers[index as usize] = buf.clone();
+    }
+
+    unsafe fn update_image_descriptor(
+        &self,
+        ds: &mut Self::DescriptorSet,
+        index: u32,
+        image: &Self::Image,
+    ) {
+        ds.images[index as usize - ds.buffers.len()] = image.clone();
+    }
+
     fn create_cmd_buf(&self) -> Result<Self::CmdBuf, Error> {
         let cmd_queue = self.cmd_queue.lock().unwrap();
         // A discussion about autorelease pools.

--- a/piet-gpu-hal/src/mux.rs
+++ b/piet-gpu-hal/src/mux.rs
@@ -391,6 +391,32 @@ impl Device {
         }
     }
 
+    pub unsafe fn update_buffer_descriptor(
+        &self,
+        ds: &mut DescriptorSet,
+        index: u32,
+        buffer: &Buffer,
+    ) {
+        mux_match! { self;
+            Device::Vk(d) => d.update_buffer_descriptor(ds.vk_mut(), index, buffer.vk()),
+            Device::Dx12(d) => d.update_buffer_descriptor(ds.dx12_mut(), index, buffer.dx12()),
+            Device::Mtl(d) => d.update_buffer_descriptor(ds.mtl_mut(), index, buffer.mtl()),
+        }
+    }
+
+    pub unsafe fn update_image_descriptor(
+        &self,
+        ds: &mut DescriptorSet,
+        index: u32,
+        image: &Image,
+    ) {
+        mux_match! { self;
+            Device::Vk(d) => d.update_image_descriptor(ds.vk_mut(), index, image.vk()),
+            Device::Dx12(d) => d.update_image_descriptor(ds.dx12_mut(), index, image.dx12()),
+            Device::Mtl(d) => d.update_image_descriptor(ds.mtl_mut(), index, image.mtl()),
+        }
+    }
+
     pub fn create_cmd_buf(&self) -> Result<CmdBuf, Error> {
         mux_match! { self;
             Device::Vk(d) => d.create_cmd_buf().map(CmdBuf::Vk),


### PR DESCRIPTION
This patch adds the capability to the HAL to update descriptor sets.

Part of the work for #175 but might be useful for other purposes (such as window resize) and is fairly self-contained.

Note that there are rustfmt changes in unrelated areas, due to rustfmt not being reliably applied through macros. I'd like to figure out a better solution to that in CI.