### PR TITLE
Make `pgpu-render`  compile on non apple platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "pgpu-render",
@@ -7,5 +8,5 @@ members = [
     "piet-gpu-hal",
     "piet-gpu-types",
     "piet-scene",
-    "tests"
+    "tests",
 ]

--- a/pgpu-render/Cargo.toml
+++ b/pgpu-render/Cargo.toml
@@ -13,6 +13,7 @@ piet-gpu = { path = "../piet-gpu" }
 piet-gpu-hal = { path = "../piet-gpu-hal" }
 piet-scene = { path = "../piet-scene" }
 
+[target.'cfg(all(not(target_arch = "wasm32"), any(target_os = "ios", target_os = "macos")))'.dependencies]
 metal = "0.22"
 cocoa = "0.24.0"
 objc = "0.2.5"

--- a/pgpu-render/build.rs
+++ b/pgpu-render/build.rs
@@ -22,6 +22,7 @@ fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     cbindgen::Builder::new()
         .with_crate(crate_dir)
+        .with_define("target_os", "ios", "__APPLE__")
         .with_header("/** Automatically generated from pgpu-render/src/lib.rs with cbindgen. **/")
         .generate()
         .expect("Unable to generate bindings")

--- a/pgpu-render/pgpu.h
+++ b/pgpu-render/pgpu.h
@@ -61,13 +61,16 @@ struct PgpuRect {
 
 extern "C" {
 
+#if defined(__APPLE__)
 /// Creates a new piet-gpu renderer for the specified Metal device and
 /// command queue.
 ///
 /// device: MTLDevice*
 /// queue: MTLCommandQueue*
 PgpuRenderer *pgpu_renderer_new(void *device, void *queue);
+#endif
 
+#if defined(__APPLE__)
 /// Renders a prepared scene into a texture target. Commands for rendering are
 /// recorded into the specified command buffer. Returns an id representing
 /// resources that may have been allocated during this process. After the
@@ -80,6 +83,7 @@ uint32_t pgpu_renderer_render(PgpuRenderer *renderer,
                               const PgpuScene *scene,
                               void *target,
                               void *cmdbuf);
+#endif
 
 /// Releases the internal resources associated with the specified id from a
 /// previous render operation.

--- a/pgpu-render/src/lib.rs
+++ b/pgpu-render/src/lib.rs
@@ -14,6 +14,16 @@
 //
 // Also licensed under MIT license, at your choice.
 
+// We only really have implementations for IOS targets so far
+// Note that this is the same cfg that wgpu uses for metal support
+#![cfg_attr(
+    not(all(
+        not(target_arch = "wasm32"),
+        any(target_os = "ios", target_os = "macos")
+    )),
+    allow(unused)
+)]
+
 mod render;
 
 use render::*;
@@ -26,6 +36,10 @@ use std::mem::transmute;
 /// device: MTLDevice*
 /// queue: MTLCommandQueue*
 #[no_mangle]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(target_os = "ios", target_os = "macos")
+))]
 pub unsafe extern "C" fn pgpu_renderer_new(
     device: *mut c_void,
     queue: *mut c_void,
@@ -44,6 +58,10 @@ pub unsafe extern "C" fn pgpu_renderer_new(
 /// target: MTLTexture*
 /// cmdbuf: MTLCommandBuffer*
 #[no_mangle]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(target_os = "ios", target_os = "macos")
+))]
 pub unsafe extern "C" fn pgpu_renderer_render(
     renderer: *mut PgpuRenderer,
     scene: *const PgpuScene,

--- a/pgpu-render/src/render.rs
+++ b/pgpu-render/src/render.rs
@@ -33,6 +33,10 @@ pub struct PgpuRenderer {
 }
 
 impl PgpuRenderer {
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        any(target_os = "ios", target_os = "macos")
+    ))]
     pub fn new(device: &metal::DeviceRef, queue: &metal::CommandQueueRef) -> Self {
         let piet_device = piet_gpu_hal::Device::new_from_raw_mtl(device, &queue);
         let session = Session::new(piet_device);
@@ -47,6 +51,10 @@ impl PgpuRenderer {
         }
     }
 
+    #[cfg(all(
+        not(target_arch = "wasm32"),
+        any(target_os = "ios", target_os = "macos")
+    ))]
     pub fn render(
         &mut self,
         scene: &PgpuScene,

--- a/piet-gpu/bin/android.rs
+++ b/piet-gpu/bin/android.rs
@@ -1,3 +1,4 @@
+#![cfg(target_os = "android")]
 //! Android example
 //!
 //! Run using `cargo apk run --example android`


### PR DESCRIPTION
This makes use of a cfg to disable the metal dependencies and the functions they are used in on ios or macos.
This is also reflected in the generated `cbindgen` code, using the `with_define` feature.

Also add `resolver="2"` to the workspace root, primarily in case we gain a `wgpu` dependency.

I've also added a fix for the android example