### PR TITLE
Expose path rendering in C API

### DIFF
--- a/piet-gpu-hal/src/backend.rs
+++ b/piet-gpu-hal/src/backend.rs
@@ -205,6 +205,9 @@ pub trait CmdBuf<D: Device> {
     /// State: ready -> finished
     unsafe fn finish(&mut self);
 
+    /// Commits any open command encoder.
+    unsafe fn flush(&mut self);
+
     /// Return true if the command buffer is suitable for reuse.
     unsafe fn reset(&mut self) -> bool;
 

--- a/piet-gpu-hal/src/dx12.rs
+++ b/piet-gpu-hal/src/dx12.rs
@@ -631,6 +631,8 @@ impl crate::backend::CmdBuf<Dx12Device> for CmdBuf {
         self.needs_reset = true;
     }
 
+    unsafe fn flush(&mut self) {}
+
     unsafe fn reset(&mut self) -> bool {
         self.allocator.reset().is_ok() && self.c.reset(&self.allocator, None).is_ok()
     }

--- a/piet-gpu-hal/src/hub.rs
+++ b/piet-gpu-hal/src/hub.rs
@@ -509,6 +509,11 @@ impl CmdBuf {
         self.cmd_buf().finish();
     }
 
+    /// Commits any open command encoder.
+    pub unsafe fn flush(&mut self) {
+        self.cmd_buf().flush();
+    }
+
     /// Begin a compute pass.
     pub unsafe fn begin_compute_pass(&mut self, desc: &ComputePassDescriptor) -> ComputePass {
         self.cmd_buf().begin_compute_pass(desc);

--- a/piet-gpu-hal/src/metal.rs
+++ b/piet-gpu-hal/src/metal.rs
@@ -590,6 +590,10 @@ impl crate::backend::CmdBuf<MtlDevice> for CmdBuf {
         self.flush_encoder();
     }
 
+    unsafe fn flush(&mut self) {
+        self.flush_encoder();
+    }
+
     unsafe fn reset(&mut self) -> bool {
         false
     }

--- a/piet-gpu-hal/src/mux.rs
+++ b/piet-gpu-hal/src/mux.rs
@@ -675,6 +675,14 @@ impl CmdBuf {
         }
     }
 
+    pub unsafe fn flush(&mut self) {
+        mux_match! { self;
+            CmdBuf::Vk(c) => c.flush(),
+            CmdBuf::Dx12(c) => c.flush(),
+            CmdBuf::Mtl(c) => c.flush(),
+        }
+    }
+
     pub unsafe fn finish(&mut self) {
         mux_match! { self;
             CmdBuf::Vk(c) => c.finish(),

--- a/piet-gpu-hal/src/vulkan.rs
+++ b/piet-gpu-hal/src/vulkan.rs
@@ -967,6 +967,8 @@ impl crate::backend::CmdBuf<VkDevice> for CmdBuf {
         self.device.device.end_command_buffer(self.cmd_buf).unwrap();
     }
 
+    unsafe fn flush(&mut self) {}
+
     unsafe fn reset(&mut self) -> bool {
         true
     }

--- a/piet-gpu/src/lib.rs
+++ b/piet-gpu/src/lib.rs
@@ -243,7 +243,10 @@ impl Renderer {
                     .unwrap()
             })
             .collect();
-        let memory_buf_dev = session.create_buffer(16 * 1024 * 1024, usage_mem_dev)?;
+        let target_dependent_size =
+            (width / TILE_W) as u64 * (height / TILE_H) as u64 * PTCL_INITIAL_ALLOC as u64;
+        let memory_buf_dev =
+            session.create_buffer(target_dependent_size + 8 * 1024 * 1024, usage_mem_dev)?;
         let memory_buf_readback =
             session.create_buffer(std::mem::size_of::<MemoryHeader>() as u64, usage_readback)?;
         let blend_buf = session.create_buffer(16 * 1024 * 1024, usage_blend)?;


### PR DESCRIPTION
This PR exposes path rendering functionality through the C API. It also contains a minimal representation of brushes (supporting only solid colors) as a foundation for extension in the future. 

There are also a few bug fixes in the renderer and HAL. Specifically, a better heuristic for calculating the initial buffer size based on target dimensions and an additional flush method on command buffers that ensures any open encoder is committed. 