### PR TITLE
Don't encode empty glyph

### DIFF
--- a/piet-scene/src/glyph.rs
+++ b/piet-scene/src/glyph.rs
@@ -87,15 +87,17 @@ impl<'a> GlyphProvider<'a> {
         let glyph = self.scaler.glyph(gid)?;
         let path = glyph.path(0)?;
         let mut fragment = SceneFragment::default();
-        let mut builder = SceneBuilder::for_fragment(&mut fragment);
-        builder.fill(
-            Fill::NonZero,
-            Affine::IDENTITY,
-            brush.unwrap_or(&Brush::Solid(Color::rgb8(255, 255, 255))),
-            None,
-            convert_path(path.elements()),
-        );
-        builder.finish();
+        if !path.verbs.is_empty() {
+            let mut builder = SceneBuilder::for_fragment(&mut fragment);
+            builder.fill(
+                Fill::NonZero,
+                Affine::IDENTITY,
+                brush.unwrap_or(&Brush::Solid(Color::rgb8(255, 255, 255))),
+                None,
+                convert_path(path.elements()),
+            );
+            builder.finish();
+        }
         Some(fragment)
     }
 


### PR DESCRIPTION
This fixes artifacts we are seeing in porting the "shello" demo to glazier, which was caused by appending glyphs with empty paths to the scene fragment. It's not obvious to me this is the best fix, as it could be done higher up by special casing glyphs with empty outlines, or lower down by allowing correct encoding of empty paths.

So partly it's a discussion of how to best fix the problem. I think a case can be made we shouldn't include empty paths in the encoding (though they can be made valid and evaluated correctly). It's likely that similar problems remain with empty paths made through the path building mechanism.