### PR TITLE
Don't reset query pool twice

### DIFF
--- a/piet-gpu/src/lib.rs
+++ b/piet-gpu/src/lib.rs
@@ -585,7 +585,9 @@ impl Renderer {
         query_pool: &QueryPool,
         query_start: u32,
     ) {
-        cmd_buf.reset_query_pool(&query_pool);
+        if query_start == 0 {
+            cmd_buf.reset_query_pool(&query_pool);
+        }
         cmd_buf.begin_debug_label("Fine raster");
         let mut pass = cmd_buf.begin_compute_pass(&ComputePassDescriptor::timer(
             &query_pool,


### PR DESCRIPTION
When invoked in non robust memory mode (ie not using RenderDriver), both the render_coarse and render_fine calls reset the query pool, which in turn causes the fetch of the query pool to hang (in Vulkan).

This is not an issue in robust memory mode because there are two different query pools, and both should indeed be reset.

This patch makes the second reset conditional on the query pool being fresh.

Fixes an observed hang with the xilem prototype on Windows.