### PR TITLE
Remove all wgsl-analyzer errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,15 @@
 {
   "wgsl-analyzer.customImports": {
     "bbox": "${workspaceFolder}/piet-wgsl/shader/shared/bbox.wgsl",
+    "blend": "${workspaceFolder}/piet-wgsl/shader/shared/blend.wgsl",
     "bump": "${workspaceFolder}/piet-wgsl/shader/shared/bump.wgsl",
     "clip": "${workspaceFolder}/piet-wgsl/shader/shared/clip.wgsl",
     "config": "${workspaceFolder}/piet-wgsl/shader/shared/config.wgsl",
     "cubic": "${workspaceFolder}/piet-wgsl/shader/shared/cubic.wgsl",
     "drawtag": "${workspaceFolder}/piet-wgsl/shader/shared/drawtag.wgsl",
-    "segment": "${workspaceFolder}/piet-wgsl/shader/shared/segment.wgsl",
     "pathtag": "${workspaceFolder}/piet-wgsl/shader/shared/pathtag.wgsl",
     "ptcl": "${workspaceFolder}/piet-wgsl/shader/shared/ptcl.wgsl",
+    "segment": "${workspaceFolder}/piet-wgsl/shader/shared/segment.wgsl",
     "tile": "${workspaceFolder}/piet-wgsl/shader/shared/tile.wgsl"
   },
   "wgsl-analyzer.diagnostics.nagaVersion": "main",

--- a/piet-wgsl/shader/backdrop.wgsl
+++ b/piet-wgsl/shader/backdrop.wgsl
@@ -28,20 +28,20 @@ fn main(
     let width_in_tiles = config.width_in_tiles;
     let ix = wg_id.x * width_in_tiles + local_id.x;
     var backdrop = 0;
-    if (local_id.x < width_in_tiles) {
+    if local_id.x < width_in_tiles {
         backdrop = tiles[ix].backdrop;
     }
     sh_backdrop[local_id.x] = backdrop;
     // iterate log2(WG_SIZE) times
     for (var i = 0u; i < firstTrailingBit(WG_SIZE); i += 1u) {
         workgroupBarrier();
-        if (local_id.x >= (1u << i)) {
+        if local_id.x >= (1u << i) {
             backdrop += sh_backdrop[local_id.x - (1u << i)];
         }
         workgroupBarrier();
         sh_backdrop[local_id.x] = backdrop;
     }
-    if (local_id.x < width_in_tiles) {
+    if local_id.x < width_in_tiles {
         tiles[ix].backdrop = backdrop;
     }
 }

--- a/piet-wgsl/shader/clip_reduce.wgsl
+++ b/piet-wgsl/shader/clip_reduce.wgsl
@@ -28,7 +28,7 @@ var<workgroup> sh_path_ix: array<u32, WG_SIZE>;
 fn main(
     @builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(local_invocation_id) local_id: vec3<u32>,
-    @builtin(workgroup_id) wg_id: vec3<u32>, 
+    @builtin(workgroup_id) wg_id: vec3<u32>,
 ) {
     let inp = clip_inp[global_id.x];
     let is_push = inp >= 0;

--- a/piet-wgsl/shader/coarse.wgsl
+++ b/piet-wgsl/shader/coarse.wgsl
@@ -189,7 +189,7 @@ fn main(
     // blend state
     var render_blend_depth = 0u;
     var max_blend_depth = 0u;
-    
+
     while true {
         for (var i = 0u; i < N_SLICE; i += 1u) {
             atomicStore(&sh_bitmaps[i][local_id.x], 0u);

--- a/piet-wgsl/shader/draw_leaf.wgsl
+++ b/piet-wgsl/shader/draw_leaf.wgsl
@@ -120,7 +120,7 @@ fn main(
         }
         if linewidth >= 0.0 {
             // Note: doesn't deal with anisotropic case
-            linewidth *= sqrt(abs(matrx.x * matrx.w - matrx.y * matrx.z)); 
+            linewidth *= sqrt(abs(matrx.x * matrx.w - matrx.y * matrx.z));
         }
         switch tag_word {
             // DRAWTAG_FILL_COLOR, DRAWTAG_FILL_IMAGE

--- a/piet-wgsl/shader/shared/blend.wgsl
+++ b/piet-wgsl/shader/shared/blend.wgsl
@@ -93,9 +93,9 @@ fn set_lum(c: vec3<f32>, l: f32) -> vec3<f32> {
 }
 
 fn set_sat_inner(
-    cmin: ptr<function, f32>, 
-    cmid: ptr<function, f32>, 
-    cmax: ptr<function, f32>, 
+    cmin: ptr<function, f32>,
+    cmid: ptr<function, f32>,
+    cmax: ptr<function, f32>,
     s: f32
 ) {
     if *cmax > *cmin {
@@ -228,10 +228,10 @@ let COMPOSE_PLUS_LIGHTER = 13u;
 // Apply general compositing operation.
 // Inputs are separated colors and alpha, output is premultiplied.
 fn blend_compose(
-    cb: vec3<f32>, 
-    cs: vec3<f32>, 
-    ab: f32, 
-    as_: f32, 
+    cb: vec3<f32>,
+    cs: vec3<f32>,
+    ab: f32,
+    as_: f32,
     mode: u32
 ) -> vec4<f32> {
     var fa = 0.0;


### PR DESCRIPTION
The only remaning cause was a missing import from the settings

I have also applied wgsl-analyzer formatting to all shaders (apart from `draw_leaf`, where the formatting is a bit messy for the long `||` condition)