### PR TITLE
Clean up unneeded type annotations in vec

### DIFF
--- a/piet-wgsl/shader/binning.wgsl
+++ b/piet-wgsl/shader/binning.wgsl
@@ -69,7 +69,7 @@ fn main(
     var y1 = 0;
     if element_ix < config.n_drawobj {
         let draw_monoid = draw_monoids[element_ix];
-        var clip_bbox = vec4<f32>(-1e9, -1e9, 1e9, 1e9);
+        var clip_bbox = vec4(-1e9, -1e9, 1e9, 1e9);
         if draw_monoid.clip_ix > 0u {
             clip_bbox = clip_bbox_buf[draw_monoid.clip_ix - 1u];
         }
@@ -79,10 +79,10 @@ fn main(
         // TODO check this is true
 
         let path_bbox = path_bbox_buf[draw_monoid.path_ix];
-        let pb = vec4<f32>(vec4<i32>(path_bbox.x0, path_bbox.y0, path_bbox.x1, path_bbox.y1));
+        let pb = vec4<f32>(vec4(path_bbox.x0, path_bbox.y0, path_bbox.x1, path_bbox.y1));
         let bbox_raw = bbox_intersect(clip_bbox, pb);
         // TODO(naga): clunky expression a workaround for broken lhs swizzle
-        let bbox = vec4<f32>(bbox_raw.xy, max(bbox_raw.xy, bbox_raw.zw));
+        let bbox = vec4(bbox_raw.xy, max(bbox_raw.xy, bbox_raw.zw));
 
         intersected_bbox[element_ix] = bbox;
         x0 = i32(floor(bbox.x * SX));

--- a/piet-wgsl/shader/clip_leaf.wgsl
+++ b/piet-wgsl/shader/clip_leaf.wgsl
@@ -110,7 +110,7 @@ fn main(
         }
     }
     let b = sh_bic[ix].b;
-    var bbox = vec4<f32>(-1e9, -1e9, 1e9, 1e9);
+    var bbox = vec4(-1e9, -1e9, 1e9, 1e9);
     if sp < b {
         let el = clip_els[ix * WG_SIZE + b - sp - 1u];
         sh_stack[local_id.x] = el.parent_ix;
@@ -134,9 +134,9 @@ fn main(
     sh_bic[local_id.x] = bic;
     if is_push {
         let path_bbox = path_bboxes[inp];
-        bbox = vec4<f32>(f32(path_bbox.x0), f32(path_bbox.y0), f32(path_bbox.x1), f32(path_bbox.y1));
+        bbox = vec4(f32(path_bbox.x0), f32(path_bbox.y0), f32(path_bbox.x1), f32(path_bbox.y1));
     } else {
-        bbox = vec4<f32>(-1e9, -1e9, 1e9, 1e9);
+        bbox = vec4(-1e9, -1e9, 1e9, 1e9);
     }
     var inbase = 0u;
     for (var i = 0u; i < firstTrailingBit(WG_SIZE) - 1u; i += 1u) {
@@ -193,7 +193,7 @@ fn main(
         } else if grandparent + i32(stack_size) >= 0 {
             bbox = sh_stack_bbox[i32(WG_SIZE) + grandparent];
         } else {
-            bbox = vec4<f32>(-1e9, -1e9, 1e9, 1e9);
+            bbox = vec4(-1e9, -1e9, 1e9, 1e9);
         }
     }
     clip_bboxes[global_id.x] = bbox;

--- a/piet-wgsl/shader/clip_reduce.wgsl
+++ b/piet-wgsl/shader/clip_reduce.wgsl
@@ -61,7 +61,7 @@ fn main(
         let path_ix = sh_path_ix[local_id.x];
         let path_bbox = path_bboxes[path_ix];
         let parent_ix = sh_parent[local_id.x] + wg_id.x * WG_SIZE;
-        let bbox = vec4<f32>(f32(path_bbox.x0), f32(path_bbox.y0), f32(path_bbox.x1), f32(path_bbox.y1));
+        let bbox = vec4(f32(path_bbox.x0), f32(path_bbox.y0), f32(path_bbox.x1), f32(path_bbox.y1));
         clip_out[global_id.x] = ClipEl(parent_ix, bbox);
     }
 }

--- a/piet-wgsl/shader/coarse.wgsl
+++ b/piet-wgsl/shader/coarse.wgsl
@@ -375,9 +375,9 @@ fn main(
                         let m1 = bitcast<f32>(info[di + 2u]);
                         let m2 = bitcast<f32>(info[di + 3u]);
                         let m3 = bitcast<f32>(info[di + 4u]);
-                        rad.matrx = vec4<f32>(m0, m1, m2, m3);
-                        rad.xlat = vec2<f32>(bitcast<f32>(info[di + 5u]), bitcast<f32>(info[di + 6u]));
-                        rad.c1 = vec2<f32>(bitcast<f32>(info[di + 7u]), bitcast<f32>(info[di + 8u]));
+                        rad.matrx = vec4(m0, m1, m2, m3);
+                        rad.xlat = vec2(bitcast<f32>(info[di + 5u]), bitcast<f32>(info[di + 6u]));
+                        rad.c1 = vec2(bitcast<f32>(info[di + 7u]), bitcast<f32>(info[di + 8u]));
                         rad.ra = bitcast<f32>(info[di + 9u]);
                         rad.roff = bitcast<f32>(info[di + 10u]);
                         write_rad_grad(rad);

--- a/piet-wgsl/shader/draw_leaf.wgsl
+++ b/piet-wgsl/shader/draw_leaf.wgsl
@@ -44,8 +44,8 @@ fn read_transform(transform_base: u32, ix: u32) -> Transform {
     let c3 = bitcast<f32>(scene[base + 3u]);
     let c4 = bitcast<f32>(scene[base + 4u]);
     let c5 = bitcast<f32>(scene[base + 5u]);
-    let matrx = vec4<f32>(c0, c1, c2, c3);
-    let translate = vec2<f32>(c4, c5);
+    let matrx = vec4(c0, c1, c2, c3);
+    let translate = vec2(c4, c5);
     return Transform(matrx, translate);
 }
 

--- a/piet-wgsl/shader/draw_leaf.wgsl
+++ b/piet-wgsl/shader/draw_leaf.wgsl
@@ -150,7 +150,7 @@ fn main(
                 let r0 = bitcast<f32>(scene[dd + 5u]);
                 let r1 = bitcast<f32>(scene[dd + 6u]);
                 let inv_det = 1.0 / (matrx.x * matrx.w - matrx.y * matrx.z);
-                let inv_mat = inv_det * vec4<f32>(matrx.w, -matrx.y, -matrx.z, matrx.x);
+                let inv_mat = inv_det * vec4(matrx.w, -matrx.y, -matrx.z, matrx.x);
                 var inv_tr = inv_mat.xz * translate.x + inv_mat.yw * translate.y;
                 inv_tr += p0;
                 let center1 = p1 - p0;

--- a/piet-wgsl/shader/path_coarse.wgsl
+++ b/piet-wgsl/shader/path_coarse.wgsl
@@ -36,14 +36,14 @@ var<private> pathdata_base: u32;
 fn read_f32_point(ix: u32) -> vec2<f32> {
     let x = bitcast<f32>(scene[pathdata_base + ix]);
     let y = bitcast<f32>(scene[pathdata_base + ix + 1u]);
-    return vec2<f32>(x, y);
+    return vec2(x, y);
 }
 
 fn read_i16_point(ix: u32) -> vec2<f32> {
     let raw = scene[pathdata_base + ix];
     let x = f32(i32(raw << 16u) >> 16u);
     let y = f32(i32(raw) >> 16u);
-    return vec2<f32>(x, y);
+    return vec2(x, y);
 }
 
 #ifndef cubics_out
@@ -276,7 +276,7 @@ fn main(
                         tile_seg.delta = dp;
                         var y_edge = mix(lp0.y, lp1.y, (tile_x0 - lp0.x) * recip_dx);
                         if xymin.x < tile_x0 {
-                            let p = vec2<f32>(tile_x0, y_edge);
+                            let p = vec2(tile_x0, y_edge);
                             if dp.x < 0.0 {
                                 tile_seg.delta = p - lp0;
                             } else {

--- a/piet-wgsl/shader/path_coarse_full.wgsl
+++ b/piet-wgsl/shader/path_coarse_full.wgsl
@@ -228,7 +228,7 @@ fn main(
                         tile_seg.delta = dp;
                         var y_edge = mix(lp0.y, lp1.y, (tile_x0 - lp0.x) * recip_dx);
                         if xymin.x < tile_x0 {
-                            let p = vec2<f32>(tile_x0, y_edge);
+                            let p = vec2(tile_x0, y_edge);
                             if dp.x < 0.0 {
                                 tile_seg.delta = p - lp0;
                             } else {

--- a/piet-wgsl/shader/pathseg.wgsl
+++ b/piet-wgsl/shader/pathseg.wgsl
@@ -75,14 +75,14 @@ var<private> pathdata_base: u32;
 fn read_f32_point(ix: u32) -> vec2<f32> {
     let x = bitcast<f32>(scene[pathdata_base + ix]);
     let y = bitcast<f32>(scene[pathdata_base + ix + 1u]);
-    return vec2<f32>(x, y);
+    return vec2(x, y);
 }
 
 fn read_i16_point(ix: u32) -> vec2<f32> {
     let raw = scene[pathdata_base + ix];
     let x = f32(i32(raw << 16u) >> 16u);
     let y = f32(i32(raw) >> 16u);
-    return vec2<f32>(x, y);
+    return vec2(x, y);
 }
 
 struct Transform {
@@ -98,8 +98,8 @@ fn read_transform(transform_base: u32, ix: u32) -> Transform {
     let c3 = bitcast<f32>(scene[base + 3u]);
     let c4 = bitcast<f32>(scene[base + 4u]);
     let c5 = bitcast<f32>(scene[base + 5u]);
-    let matrx = vec4<f32>(c0, c1, c2, c3);
-    let translate = vec2<f32>(c4, c5);
+    let matrx = vec4(c0, c1, c2, c3);
+    let translate = vec2(c4, c5);
     return Transform(matrx, translate);
 }
 
@@ -162,10 +162,9 @@ fn main(
             }
         }
         let transform = read_transform(config.transform_base, tm.trans_ix);
-        //let transform = Transform(vec4<f32>(1.0, 0.0, 0.0, 1.0), vec2<f32>());
         p0 = transform_apply(transform, p0);
         p1 = transform_apply(transform, p1);
-        var bbox = vec4<f32>(min(p0, p1), max(p0, p1));
+        var bbox = vec4(min(p0, p1), max(p0, p1));
         // Degree-raise
         if seg_type == PATH_TAG_LINETO {
             p3 = p1;
@@ -173,10 +172,10 @@ fn main(
             p1 = mix(p0, p3, 1.0 / 3.0);
         } else if seg_type >= PATH_TAG_QUADTO {
             p2 = transform_apply(transform, p2);
-            bbox = vec4<f32>(min(bbox.xy, p2), max(bbox.zw, p2));
+            bbox = vec4(min(bbox.xy, p2), max(bbox.zw, p2));
             if seg_type == PATH_TAG_CUBICTO {
                 p3 = transform_apply(transform, p3);
-                bbox = vec4<f32>(min(bbox.xy, p3), max(bbox.zw, p3));
+                bbox = vec4(min(bbox.xy, p3), max(bbox.zw, p3));
             } else {
                 p3 = p2;
                 p2 = mix(p1, p2, 1.0 / 3.0);
@@ -187,8 +186,8 @@ fn main(
             // See https://www.iquilezles.org/www/articles/ellipses/ellipses.htm
             // This is the correct bounding box, but we're not handling rendering
             // in the isotropic case, so it may mismatch.
-            let stroke = 0.5 * linewidth * vec2<f32>(length(transform.matrx.xz), length(transform.matrx.yw));
-            bbox += vec4<f32>(-stroke, stroke);
+            let stroke = 0.5 * linewidth * vec2(length(transform.matrx.xz), length(transform.matrx.yw));
+            bbox += vec4(-stroke, stroke);
         }
         cubics[global_id.x] = Cubic(p0, p1, p2, p3, tm.path_ix, 0u);
         // Update bounding box using atomics only. Computing a monoid is a

--- a/piet-wgsl/shader/shared/blend.wgsl
+++ b/piet-wgsl/shader/shared/blend.wgsl
@@ -45,23 +45,23 @@ fn color_burn(cb: f32, cs: f32) -> f32 {
 }
 
 fn hard_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
-    return mix(
+    return select(
         screen(cb, 2.0 * cs - 1.0),
         cb * 2.0 * cs,
-        vec3<f32>(cs <= vec3<f32>(0.5))
+        cs <= vec3(0.5)
     );
 }
 
 fn soft_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
-    let d = mix(
+    let d = select(
         sqrt(cb),
-        ((16.0 * cb - vec3(12.0)) * cb + vec3(4.0)) * cb,
-        vec3<f32>(cb <= vec3<f32>(0.25))
+        ((16.0 * cb - 12.0) * cb + 4.0) * cb,
+        cb <= vec3(0.25)
     );
-    return mix(
-        cb + (2.0 * cs - vec3(1.0)) * (d - cb),
-        cb - (vec3(1.0) - 2.0 * cs) * cb * (vec3(1.0) - cb),
-        vec3<f32>(cs <= vec3<f32>(0.5))
+    return select(
+        cb + (2.0 * cs - 1.0) * (d - cb),
+        cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb),
+        (cs <= vec3(0.5))
     );
 }
 
@@ -70,7 +70,7 @@ fn sat(c: vec3<f32>) -> f32 {
 }
 
 fn lum(c: vec3<f32>) -> f32 {
-    let f = vec3<f32>(0.3, 0.59, 0.11);
+    let f = vec3(0.3, 0.59, 0.11);
     return dot(c, f);
 }
 
@@ -133,13 +133,13 @@ fn set_sat(c: vec3<f32>, s: f32) -> vec3<f32> {
             }
         }
     }
-    return vec3<f32>(r, g, b);
+    return vec3(r, g, b);
 }
 
 // Blends two RGB colors together. The colors are assumed to be in sRGB
 // color space, and this function does not take alpha into account.
 fn blend_mix(cb: vec3<f32>, cs: vec3<f32>, mode: u32) -> vec3<f32> {
-    var b = vec3<f32>(0.0);
+    var b = vec3(0.0);
     switch mode {
         // MIX_MULTIPLY
         case 1u: {
@@ -163,11 +163,11 @@ fn blend_mix(cb: vec3<f32>, cs: vec3<f32>, mode: u32) -> vec3<f32> {
         }
         // MIX_COLOR_DODGE
         case 6u: {
-            b = vec3<f32>(color_dodge(cb.x, cs.x), color_dodge(cb.y, cs.y), color_dodge(cb.z, cs.z));
+            b = vec3(color_dodge(cb.x, cs.x), color_dodge(cb.y, cs.y), color_dodge(cb.z, cs.z));
         }
         // MIX_COLOR_BURN
         case 7u: {
-            b = vec3<f32>(color_burn(cb.x, cs.x), color_burn(cb.y, cs.y), color_burn(cb.z, cs.z));
+            b = vec3(color_burn(cb.x, cs.x), color_burn(cb.y, cs.y), color_burn(cb.z, cs.z));
         }
         // MIX_HARD_LIGHT
         case 8u: {
@@ -299,14 +299,14 @@ fn blend_compose(
         }
         // COMPOSE_PLUS_LIGHTER
         case 13u: {
-            return min(vec4<f32>(1.0), vec4<f32>(as_ * cs + ab * cb, as_ + ab));
+            return min(vec4(1.0), vec4(as_ * cs + ab * cb, as_ + ab));
         }
         default: {}
     }
     let as_fa = as_ * fa;
     let ab_fb = ab * fb;
     let co = as_fa * cs + ab_fb * cb;
-    return vec4<f32>(co, as_fa + ab_fb);
+    return vec4(co, as_fa + ab_fb);
 }
 
 // Apply color mixing and composition. Both input and output colors are
@@ -329,7 +329,7 @@ fn blend_mix_compose(backdrop: vec4<f32>, src: vec4<f32>, mode: u32) -> vec4<f32
     let compose_mode = mode & 0xffu;
     if compose_mode == COMPOSE_SRC_OVER {
         let co = mix(backdrop.rgb, cs, src.a);
-        return vec4<f32>(co, src.a + backdrop.a * (1.0 - src.a));
+        return vec4(co, src.a + backdrop.a * (1.0 - src.a));
     } else {
         return blend_compose(cb, cs, backdrop.a, src.a, compose_mode);
     }

--- a/piet-wgsl/shader/shared/blend.wgsl
+++ b/piet-wgsl/shader/shared/blend.wgsl
@@ -61,7 +61,7 @@ fn soft_light(cb: vec3<f32>, cs: vec3<f32>) -> vec3<f32> {
     return select(
         cb + (2.0 * cs - 1.0) * (d - cb),
         cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb),
-        (cs <= vec3(0.5))
+        cs <= vec3(0.5)
     );
 }
 

--- a/piet-wgsl/shader/tile_alloc.wgsl
+++ b/piet-wgsl/shader/tile_alloc.wgsl
@@ -81,7 +81,7 @@ fn main(
     storageBarrier();
     if drawobj_ix < config.n_drawobj {
         let tile_subix = select(0u, sh_tile_count[local_id.x - 1u], local_id.x > 0u);
-        let bbox = vec4<u32>(ux0, uy0, ux1, uy1);
+        let bbox = vec4(ux0, uy0, ux1, uy1);
         let path = Path(bbox, tile_offset + tile_subix);
         paths[drawobj_ix] = path;
     }


### PR DESCRIPTION
Now that wgsl-analyzer 0.6 is released, most explicit type annotations on vec can be dropped (the exception being when it is a type conversion).

Also changes mix to select when the selector is actually boolean.