### PR TITLE
Make the WGSL port interactive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +269,7 @@ dependencies = [
  "cocoa-foundation",
  "core-foundation",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -269,7 +284,7 @@ dependencies = [
  "block",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "objc",
 ]
@@ -309,7 +324,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -321,7 +336,19 @@ checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags",
  "core-foundation",
- "foreign-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-text"
+version = "19.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
+dependencies = [
+ "core-foundation",
+ "core-graphics",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -332,6 +359,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossfont"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21fd3add36ea31aba1520aa5288714dd63be506106753226d0eb387a93bc9c45"
+dependencies = [
+ "cocoa",
+ "core-foundation",
+ "core-foundation-sys",
+ "core-graphics",
+ "core-text",
+ "dwrote",
+ "foreign-types 0.5.0",
+ "freetype-rs",
+ "libc",
+ "log",
+ "objc",
+ "once_cell",
+ "pkg-config",
+ "servo-fontconfig",
+ "winapi",
 ]
 
 [[package]]
@@ -443,6 +493,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dwrote"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439a1c2ba5611ad3ed731280541d36d2e9c4ac5e7fb818a27b604bdc5a6aa65b"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde_derive",
+ "winapi",
+ "wio",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +517,16 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "expat-sys"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+dependencies = [
+ "cmake",
+ "pkg-config",
 ]
 
 [[package]]
@@ -486,7 +560,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8469d0d40519bc608ec6863f1cc88f3f1deee15913f2f3b3e573d81ed38cccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -494,6 +589,34 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "freetype-rs"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74eadec9d0a5c28c54bb9882e54787275152a4e36ce206b45d7451384e5bf5fb"
+dependencies = [
+ "bitflags",
+ "freetype-sys",
+ "libc",
+]
+
+[[package]]
+name = "freetype-sys"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37d4011c0cc628dfa766fcc195454f4b068d7afdc2adfd28861191d866e731a"
+dependencies = [
+ "cmake",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "futures-core"
@@ -800,7 +923,7 @@ dependencies = [
  "bitflags",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "log",
  "objc",
 ]
@@ -1136,7 +1259,7 @@ dependencies = [
  "bytemuck",
  "cocoa-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "metal",
  "objc",
  "raw-window-handle 0.5.0",
@@ -1188,6 +1311,7 @@ dependencies = [
  "pollster",
  "roxmltree",
  "wgpu",
+ "winit",
 ]
 
 [[package]]
@@ -1450,6 +1574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "safe_arch"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ff3d6d9696af502cc3110dacce942840fb06ff4514cad92236ecc455f2ce05"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1593,18 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61270629cc6b4d77ec1907db1033d5c2e1a404c412743621981a871dc9c12339"
+dependencies = [
+ "crossfont",
+ "log",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
 
 [[package]]
 name = "serde"
@@ -1490,6 +1635,27 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "servo-fontconfig"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e3e22fe5fd73d04ebf0daa049d3efe3eae55369ce38ab16d07ddd9ac5c217c"
+dependencies = [
+ "libc",
+ "servo-fontconfig-sys",
+]
+
+[[package]]
+name = "servo-fontconfig-sys"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36b879db9892dfa40f95da1c38a835d41634b825fbd8c4c418093d53c24b388"
+dependencies = [
+ "expat-sys",
+ "freetype-sys",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1627,6 +1793,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.5.2",
+ "bytemuck",
+ "cfg-if",
+ "png",
+ "safe_arch",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
 ]
 
 [[package]]
@@ -1895,7 +2086,7 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
+ "foreign-types 0.3.2",
  "fxhash",
  "glow",
  "gpu-alloc",
@@ -2083,6 +2274,7 @@ dependencies = [
  "percent-encoding",
  "raw-window-handle 0.4.3",
  "raw-window-handle 0.5.0",
+ "sctk-adwaita",
  "smithay-client-toolkit",
  "wasm-bindgen",
  "wayland-client",

--- a/piet-wgsl/Cargo.toml
+++ b/piet-wgsl/Cargo.toml
@@ -18,3 +18,6 @@ piet-scene = { path = "../piet-scene" }
 
 # for picosvg, should be split out
 roxmltree = "0.13"
+
+# move this to an example
+winit = "0.27.5"

--- a/piet-wgsl/shader/shared/config.wgsl
+++ b/piet-wgsl/shader/shared/config.wgsl
@@ -4,6 +4,9 @@ struct Config {
     width_in_tiles: u32,
     height_in_tiles: u32,
 
+    target_width: u32,
+    target_height: u32,
+
     n_drawobj: u32,
     n_path: u32,
     n_clip: u32,

--- a/piet-wgsl/src/main.rs
+++ b/piet-wgsl/src/main.rs
@@ -16,12 +16,11 @@
 
 //! A simple application to run a compute shader.
 
-use std::{fs::File, io::BufWriter};
+use engine::{Engine, Error, ExternalResource};
 
-use engine::Engine;
-
-use render::next_multiple_of;
-use wgpu::{Device, Limits, Queue};
+use piet_scene::{Scene, SceneBuilder};
+use wgpu::{Device, Instance, Limits, Queue, Surface, SurfaceConfiguration};
+use winit::window::Window;
 
 mod debug;
 mod engine;
@@ -29,103 +28,321 @@ mod pico_svg;
 mod ramp;
 mod render;
 mod shaders;
+mod simple_text;
 mod test_scene;
 
-async fn run(dimensions: &Dimensions) -> Result<(), Box<dyn std::error::Error>> {
-    let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
-    let adapter = instance.request_adapter(&Default::default()).await.unwrap();
-    let features = adapter.features();
-    let mut limits = Limits::default();
-    limits.max_storage_buffers_per_shader_stage = 16;
-    let (device, queue) = adapter
-        .request_device(
-            &wgpu::DeviceDescriptor {
-                label: None,
-                features: features & wgpu::Features::TIMESTAMP_QUERY,
-                limits,
-            },
-            None,
-        )
-        .await?;
-    let mut engine = Engine::new();
-    do_render(&device, &queue, &mut engine, dimensions).await?;
-
-    Ok(())
-}
-
-fn dump_buf(buf: &[u32]) {
-    for (i, val) in buf.iter().enumerate() {
-        if *val != 0 {
-            let lo = val & 0x7fff_ffff;
-            if lo >= 0x3000_0000 && lo < 0x5000_0000 {
-                println!("{}: {:x} {}", i, val, f32::from_bits(*val));
-            } else {
-                println!("{}: {:x}", i, val);
-            }
-        }
-    }
-}
-
-async fn do_render(
-    device: &Device,
-    queue: &Queue,
-    engine: &mut Engine,
-    dimensions: &Dimensions,
-) -> Result<(), Box<dyn std::error::Error>> {
-    #[allow(unused)]
-    let shaders = shaders::init_shaders(device, engine)?;
-    let full_shaders = shaders::full_shaders(device, engine)?;
-    let scene = test_scene::gen_test_scene();
-    //test_scene::dump_scene_info(&scene);
-    //let (recording, buf) = render::render(&scene, &shaders);
-    let (recording, buf) = render::render_full(&scene, &full_shaders, dimensions);
-    let downloads = engine.run_recording(&device, &queue, &recording)?;
-    let mapped = downloads.map();
-    device.poll(wgpu::Maintain::Wait);
-    let buf = mapped.get_mapped(buf).await?;
-
-    if false {
-        dump_buf(bytemuck::cast_slice(&buf));
-    } else {
-        let file = File::create("image.png")?;
-        let w = BufWriter::new(file);
-        let mut encoder = png::Encoder::new(w, dimensions.width, dimensions.height);
-        encoder.set_color(png::ColorType::Rgba);
-        let mut writer = encoder.write_header()?;
-        let expected_size = (dimensions.width * dimensions.height * 4) as usize;
-
-        let new_width = next_multiple_of(dimensions.width, 16) as usize;
-
-        if expected_size == buf.len() {
-            writer.write_image_data(&buf)?;
-        } else {
-            let mut output = Vec::<u8>::with_capacity(expected_size * 4);
-            for height in 0..(dimensions.height as usize) {
-                output.extend_from_slice(
-                    &buf[height * new_width * 4..][..dimensions.width as usize * 4],
-                );
-            }
-            writer.write_image_data(&output)?;
-        }
-    }
-    Ok(())
-}
+use pico_svg::PicoSvg;
+use simple_text::SimpleText;
 
 pub struct Dimensions {
     width: u32,
     height: u32,
 }
 
+pub struct WgpuState {
+    pub instance: Instance,
+    pub device: Device,
+    pub queue: Queue,
+    pub surface: Option<Surface>,
+    pub surface_config: SurfaceConfiguration,
+}
+
+impl WgpuState {
+    pub async fn new(window: Option<&Window>) -> Result<Self, Box<dyn std::error::Error>> {
+        let instance = Instance::new(wgpu::Backends::PRIMARY);
+        let adapter = instance.request_adapter(&Default::default()).await.unwrap();
+        let features = adapter.features();
+        let mut limits = Limits::default();
+        limits.max_storage_buffers_per_shader_stage = 16;
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    features: features
+                        & (wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::CLEAR_TEXTURE),
+                    limits,
+                },
+                None,
+            )
+            .await?;
+        let (surface, surface_config) = if let Some(window) = window {
+            let surface = unsafe { instance.create_surface(window) };
+            let size = window.inner_size();
+            // let format = surface.get_supported_formats(&adapter)[0];
+            let format = wgpu::TextureFormat::Bgra8Unorm;
+            println!("surface: {:?} {:?}", size, format);
+            let surface_config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format,
+                width: size.width,
+                height: size.height,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            };
+            surface.configure(&device, &surface_config);
+            (Some(surface), surface_config)
+        } else {
+            let surface_config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::empty(),
+                format: wgpu::TextureFormat::Bgra8Unorm,
+                width: 0,
+                height: 0,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            };
+            (None, surface_config)
+        };
+        Ok(Self {
+            instance,
+            device,
+            queue,
+            surface,
+            surface_config,
+        })
+    }
+
+    pub fn create_target_texture(&self) -> (wgpu::Texture, wgpu::TextureView) {
+        let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+            label: None,
+            size: wgpu::Extent3d {
+                width: self.surface_config.width,
+                height: self.surface_config.height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        (texture, view)
+    }
+}
+
+async fn run_interactive() -> Result<(), Error> {
+    use winit::{
+        dpi::LogicalSize,
+        event::*,
+        event_loop::{ControlFlow, EventLoop},
+        window::WindowBuilder,
+    };
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new()
+        .with_inner_size(LogicalSize::new(1044, 800))
+        .with_resizable(true)
+        .build(&event_loop)
+        .unwrap();
+    let mut state = WgpuState::new(Some(&window)).await?;
+    let mut engine = Engine::new();
+    let full_shaders = shaders::full_shaders(&state.device, &mut engine)?;
+    let (blit_layout, blit_pipeline) = create_blit_pipeline(&state);
+    let mut simple_text = SimpleText::new();
+    let mut current_frame = 0usize;
+    let mut scene_ix = 0usize;
+    let (mut _target_texture, mut target_view) = state.create_target_texture();
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::WindowEvent {
+            ref event,
+            window_id,
+        } if window_id == window.id() => match event {
+            WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+            WindowEvent::KeyboardInput { input, .. } => {
+                if input.state == ElementState::Pressed {
+                    match input.virtual_keycode {
+                        Some(VirtualKeyCode::Left) => scene_ix = scene_ix.saturating_sub(1),
+                        Some(VirtualKeyCode::Right) => scene_ix = scene_ix.saturating_add(1),
+                        _ => {}
+                    }
+                }
+            }
+            WindowEvent::Resized(size) => {
+                state.surface_config.width = size.width;
+                state.surface_config.height = size.height;
+                state
+                    .surface
+                    .as_ref()
+                    .unwrap()
+                    .configure(&state.device, &state.surface_config);
+                let (t, v) = state.create_target_texture();
+                _target_texture = t;
+                target_view = v;
+                window.request_redraw();
+            }
+            _ => {}
+        },
+        Event::MainEventsCleared => {
+            window.request_redraw();
+        }
+        Event::RedrawRequested(_) => {
+            current_frame += 1;
+            let surface_texture = state
+                .surface
+                .as_ref()
+                .unwrap()
+                .get_current_texture()
+                .unwrap();
+            let dimensions = Dimensions {
+                width: state.surface_config.width,
+                height: state.surface_config.height,
+            };
+            let mut scene = Scene::default();
+            let mut builder = SceneBuilder::for_scene(&mut scene);
+            const N_SCENES: usize = 6;
+            match scene_ix % N_SCENES {
+                0 => test_scene::render_anim_frame(&mut builder, &mut simple_text, current_frame),
+                1 => test_scene::render_blend_grid(&mut builder),
+                2 => test_scene::render_tiger(&mut builder, false),
+                3 => test_scene::render_brush_transform(&mut builder, current_frame),
+                4 => test_scene::render_funky_paths(&mut builder),
+                _ => test_scene::render_scene(&mut builder),
+            }
+            builder.finish();
+            let (recording, target) = render::render_full(&scene, &full_shaders, &dimensions);
+            let external_resources = [ExternalResource::Image(
+                *target.as_image().unwrap(),
+                &target_view,
+            )];
+            let _ = engine
+                .run_recording(&state.device, &state.queue, &recording, &external_resources)
+                .unwrap();
+            let mut encoder = state
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            {
+                let surface_view = surface_texture
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let bind_group = state.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: None,
+                    layout: &blit_layout,
+                    entries: &[wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&target_view),
+                    }],
+                });
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &surface_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color::default()),
+                            store: true,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                });
+                render_pass.set_pipeline(&blit_pipeline);
+                render_pass.set_bind_group(0, &bind_group, &[]);
+                render_pass.draw(0..6, 0..1);
+            }
+            state.queue.submit(Some(encoder.finish()));
+            surface_texture.present();
+        }
+        _ => {}
+    });
+}
+
 fn main() {
-    let mut args = std::env::args();
-    args.next();
-    let width = args
-        .next()
-        .and_then(|it| it.parse::<u32>().ok())
-        .unwrap_or(1024);
-    let height = args
-        .next()
-        .and_then(|it| it.parse::<u32>().ok())
-        .unwrap_or(1024);
-    pollster::block_on(run(&Dimensions { width, height })).unwrap();
+    pollster::block_on(run_interactive()).unwrap();
+}
+
+// Fit this into the recording code somehow?
+fn create_blit_pipeline(state: &WgpuState) -> (wgpu::BindGroupLayout, wgpu::RenderPipeline) {
+    const SHADERS: &str = r#"
+        @vertex
+        fn vs_main(@builtin(vertex_index) ix: u32) -> @builtin(position) vec4<f32> {
+            // Generate a full screen quad in NDCs
+            var vertex = vec2<f32>(-1.0, 1.0);
+            switch ix {
+                case 1u: {
+                    vertex = vec2<f32>(-1.0, -1.0);
+                }
+                case 2u, 4u: {
+                    vertex = vec2<f32>(1.0, -1.0);
+                }
+                case 5u: {
+                    vertex = vec2<f32>(1.0, 1.0);
+                }
+                default: {}
+            }
+            return vec4<f32>(vertex, 0.0, 1.0);
+        }
+        
+        @group(0) @binding(0)
+        var fine_output: texture_2d<f32>;
+        
+        @fragment
+        fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
+            return textureLoad(fine_output, vec2<i32>(pos.xy), 0);
+        }
+    "#;
+
+    let shader = state
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("blit shaders"),
+            source: wgpu::ShaderSource::Wgsl(SHADERS.into()),
+        });
+    let bind_group_layout =
+        state
+            .device
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: None,
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    binding: 0,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                }],
+            });
+    let pipeline_layout = state
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+    let pipeline = state
+        .device
+        .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: state.surface_config.format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: Some(wgpu::Face::Back),
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+        });
+    (bind_group_layout, pipeline)
 }

--- a/piet-wgsl/src/shaders.rs
+++ b/piet-wgsl/src/shaders.rs
@@ -22,7 +22,7 @@ use std::{collections::HashSet, fs, path::Path};
 
 use wgpu::Device;
 
-use crate::engine::{BindType, Engine, Error, ShaderId};
+use crate::engine::{BindType, Engine, Error, ImageFormat, ShaderId};
 
 pub const PATHTAG_REDUCE_WG: u32 = 256;
 pub const PATH_BBOX_WG: u32 = 256;
@@ -281,9 +281,9 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
             BindType::BufReadOnly,
             BindType::BufReadOnly,
             BindType::BufReadOnly,
-            BindType::Buffer,
+            BindType::Image(ImageFormat::Rgba8),
             BindType::BufReadOnly,
-            BindType::ImageRead,
+            BindType::ImageRead(ImageFormat::Rgba8),
         ],
     )?;
     Ok(FullShaders {

--- a/piet-wgsl/src/simple_text.rs
+++ b/piet-wgsl/src/simple_text.rs
@@ -1,0 +1,81 @@
+// Copyright 2022 The piet-gpu authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Also licensed under MIT license, at your choice.
+
+use piet_scene::glyph::{pinot, pinot::TableProvider, GlyphContext};
+use piet_scene::kurbo::Affine;
+use piet_scene::{Brush, SceneBuilder};
+
+pub use pinot::FontRef;
+
+// This is very much a hack to get things working.
+// On Windows, can set this to "c:\\Windows\\Fonts\\seguiemj.ttf" to get color emoji
+const FONT_DATA: &[u8] = include_bytes!("../../piet-gpu/third-party/Roboto-Regular.ttf");
+
+pub struct SimpleText {
+    gcx: GlyphContext,
+}
+
+impl SimpleText {
+    pub fn new() -> Self {
+        Self {
+            gcx: GlyphContext::new(),
+        }
+    }
+
+    pub fn add(
+        &mut self,
+        builder: &mut SceneBuilder,
+        font: Option<&FontRef>,
+        size: f32,
+        brush: Option<&Brush>,
+        transform: Affine,
+        text: &str,
+    ) {
+        let font = font.unwrap_or(&FontRef {
+            data: FONT_DATA,
+            offset: 0,
+        });
+        if let Some(cmap) = font.cmap() {
+            if let Some(hmtx) = font.hmtx() {
+                let upem = font.head().map(|head| head.units_per_em()).unwrap_or(1000) as f64;
+                let scale = size as f64 / upem;
+                let vars: [(pinot::types::Tag, f32); 0] = [];
+                let mut provider = self.gcx.new_provider(font, None, size, false, vars);
+                let hmetrics = hmtx.hmetrics();
+                let default_advance = hmetrics
+                    .get(hmetrics.len().saturating_sub(1))
+                    .map(|h| h.advance_width)
+                    .unwrap_or(0);
+                let mut pen_x = 0f64;
+                for ch in text.chars() {
+                    let gid = cmap.map(ch as u32).unwrap_or(0);
+                    let advance = hmetrics
+                        .get(gid as usize)
+                        .map(|h| h.advance_width)
+                        .unwrap_or(default_advance) as f64
+                        * scale;
+                    if let Some(glyph) = provider.get(gid, brush) {
+                        let xform = transform
+                            * Affine::translate((pen_x, 0.0))
+                            * Affine::scale_non_uniform(1.0, -1.0);
+                        builder.append(&glyph, Some(xform));
+                    }
+                    pen_x += advance;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds the infrastructure to support writeable images and also hacks in a method for supplying external resources while running a recording. There are better designs for this, but I suspect that there will be a lot of refactoring around that code so I didn't want to invest a ton of effort here right now.

Changes fine to output to a texture instead of a buffer and also hacks in a small render pass to blit this texture to swapchain texture.

Finally, runs it all in a window with the original piet-gpu test scenes. There are some artifacts on wide strokes, but otherwise seems to be about right.

As usual with me, seems to be a lot of churn here :)