### PR TITLE
Fix rendering artifacts with strokes

### DIFF
--- a/piet-wgsl/shader/pathseg.wgsl
+++ b/piet-wgsl/shader/pathseg.wgsl
@@ -181,7 +181,7 @@ fn main(
                 p1 = mix(p1, p0, 1.0 / 3.0);
             }
         }
-        var stroke = vec2<f32>(0.0, 0.0);
+        var stroke = vec2(0.0, 0.0);
         if linewidth >= 0.0 {
             // See https://www.iquilezles.org/www/articles/ellipses/ellipses.htm
             // This is the correct bounding box, but we're not handling rendering

--- a/piet-wgsl/shader/shared/cubic.wgsl
+++ b/piet-wgsl/shader/shared/cubic.wgsl
@@ -5,7 +5,9 @@ struct Cubic {
     p1: vec2<f32>,
     p2: vec2<f32>,
     p3: vec2<f32>,
+    stroke: vec2<f32>,
     path_ix: u32,
-    // Needed?
-    padding: u32,
+    flags: u32,
 }
+
+let CUBIC_IS_STROKE = 1u;

--- a/piet-wgsl/src/render.rs
+++ b/piet-wgsl/src/render.rs
@@ -11,7 +11,7 @@ use crate::{
 const TAG_MONOID_SIZE: u64 = 12;
 const TAG_MONOID_FULL_SIZE: u64 = 20;
 const PATH_BBOX_SIZE: u64 = 24;
-const CUBIC_SIZE: u64 = 40;
+const CUBIC_SIZE: u64 = 48;
 const DRAWMONOID_SIZE: u64 = 16;
 const MAX_DRAWINFO_SIZE: u64 = 44;
 const CLIP_BIC_SIZE: u64 = 8;


### PR DESCRIPTION
A number of things weren't being computed correctly for strokes, including bounding boxes and also incorrectly applying y_edge logic (which is only correct for fills).