### PR TITLE
Hodgepodge of small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,6 +1704,7 @@ dependencies = [
  "piet-wgsl",
  "pollster",
  "roxmltree",
+ "wgpu",
  "winit 0.27.5",
 ]
 

--- a/piet-wgsl/examples/winit/Cargo.toml
+++ b/piet-wgsl/examples/winit/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+wgpu = "0.14"
 piet-wgsl = { path = "../../../piet-wgsl" }
 piet-scene = { path = "../../../piet-scene" }
 winit = "0.27.5"

--- a/piet-wgsl/examples/winit/src/main.rs
+++ b/piet-wgsl/examples/winit/src/main.rs
@@ -96,6 +96,7 @@ async fn run() -> Result<()> {
                 )
                 .expect("failed to render to surface");
             surface_texture.present();
+            render_cx.device.poll(wgpu::Maintain::Wait);
         }
         _ => {}
     });

--- a/piet-wgsl/shader/fine.wgsl
+++ b/piet-wgsl/shader/fine.wgsl
@@ -282,8 +282,9 @@ fn main(
         let coords = xy_uint + vec2(i, 0u);
         if coords.x < config.target_width && coords.y < config.target_height {
             let fg = rgba[i];
-            let a_inv = 1.0 / (fg.a + 1e-6);
-            let rgba_sep = vec4(fg.r * a_inv, fg.g * a_inv, fg.b * a_inv, fg.a);            
+            // Max with a small epsilon to avoid NaNs
+            let a_inv = 1.0 / max(fg.a, 1e-6);
+            let rgba_sep = vec4(fg.rgb * a_inv, fg.a);            
             textureStore(output, vec2<i32>(coords), rgba_sep);
         }
     } 

--- a/piet-wgsl/shader/fine.wgsl
+++ b/piet-wgsl/shader/fine.wgsl
@@ -281,7 +281,10 @@ fn main(
     for (var i = 0u; i < PIXELS_PER_THREAD; i += 1u) {
         let coords = xy_uint + vec2(i, 0u);
         if coords.x < config.target_width && coords.y < config.target_height {
-            textureStore(output, vec2<i32>(coords), rgba[i]);
+            let fg = rgba[i];
+            let a_inv = 1.0 / (fg.a + 1e-6);
+            let rgba_sep = vec4(fg.r * a_inv, fg.g * a_inv, fg.b * a_inv, fg.a);            
+            textureStore(output, vec2<i32>(coords), rgba_sep);
         }
     } 
 #else

--- a/piet-wgsl/shader/shared/blend.wgsl
+++ b/piet-wgsl/shader/shared/blend.wgsl
@@ -318,10 +318,10 @@ fn blend_mix_compose(backdrop: vec4<f32>, src: vec4<f32>, mode: u32) -> vec4<f32
         // Both normal+src_over blend and clip case
         return backdrop * (1.0 - src.a) + src;
     }
-    // Un-premultiply colors for blending
-    let inv_src_a = 1.0 / (src.a + EPSILON);
+    // Un-premultiply colors for blending. Max with a small epsilon to avoid NaNs.
+    let inv_src_a = 1.0 / max(src.a, EPSILON);
     var cs = src.rgb * inv_src_a;
-    let inv_backdrop_a = 1.0 / (backdrop.a + EPSILON);
+    let inv_backdrop_a = 1.0 / max(backdrop.a, EPSILON);
     let cb = backdrop.rgb * inv_backdrop_a;
     let mix_mode = mode >> 8u;
     let mixed = blend_mix(cb, cs, mix_mode);

--- a/piet-wgsl/src/lib.rs
+++ b/piet-wgsl/src/lib.rs
@@ -205,7 +205,7 @@ impl BlitPipeline {
             @fragment
             fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
                 let rgba_sep = textureLoad(fine_output, vec2<i32>(pos.xy), 0);
-                return vec4(rgba_sep.rgb * rgba_sep.a, 1.0);
+                return vec4(rgba_sep.rgb * rgba_sep.a, rgba_sep.a);
             }
         "#;
 

--- a/piet-wgsl/src/lib.rs
+++ b/piet-wgsl/src/lib.rs
@@ -143,7 +143,6 @@ impl Renderer {
 }
 
 struct TargetTexture {
-    texture: Texture,
     view: TextureView,
     width: u32,
     height: u32,
@@ -166,7 +165,6 @@ impl TargetTexture {
         });
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         Self {
-            texture,
             view,
             width,
             height,
@@ -185,20 +183,20 @@ impl BlitPipeline {
             @vertex
             fn vs_main(@builtin(vertex_index) ix: u32) -> @builtin(position) vec4<f32> {
                 // Generate a full screen quad in NDCs
-                var vertex = vec2<f32>(-1.0, 1.0);
+                var vertex = vec2(-1.0, 1.0);
                 switch ix {
                     case 1u: {
-                        vertex = vec2<f32>(-1.0, -1.0);
+                        vertex = vec2(-1.0, -1.0);
                     }
                     case 2u, 4u: {
-                        vertex = vec2<f32>(1.0, -1.0);
+                        vertex = vec2(1.0, -1.0);
                     }
                     case 5u: {
-                        vertex = vec2<f32>(1.0, 1.0);
+                        vertex = vec2(1.0, 1.0);
                     }
                     default: {}
                 }
-                return vec4<f32>(vertex, 0.0, 1.0);
+                return vec4(vertex, 0.0, 1.0);
             }
             
             @group(0) @binding(0)
@@ -206,7 +204,8 @@ impl BlitPipeline {
             
             @fragment
             fn fs_main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
-                return textureLoad(fine_output, vec2<i32>(pos.xy), 0);
+                let rgba_sep = textureLoad(fine_output, vec2<i32>(pos.xy), 0);
+                return vec4(rgba_sep.rgb * rgba_sep.a, 1.0);
             }
         "#;
 

--- a/piet-wgsl/src/shaders.rs
+++ b/piet-wgsl/src/shaders.rs
@@ -32,7 +32,7 @@ pub const CLIP_REDUCE_WG: u32 = 256;
 
 macro_rules! shader {
     ($name:expr) => {
-        include_str!(concat!(concat!("../shader/", $name), ".wgsl"))
+        include_str!(concat!("../shader/", $name, ".wgsl"))
     };
 }
 
@@ -314,7 +314,7 @@ macro_rules! shared_shader {
     ($name:expr) => {
         (
             $name,
-            include_str!(concat!(concat!("../shader/shared/", $name), ".wgsl")),
+            include_str!(concat!("../shader/shared/", $name, ".wgsl")),
         )
     };
 }
@@ -326,7 +326,6 @@ const SHARED_SHADERS: &[(&str, &str)] = &[
     shared_shader!("clip"),
     shared_shader!("config"),
     shared_shader!("cubic"),
-    shared_shader!("bbox"),
     shared_shader!("drawtag"),
     shared_shader!("pathtag"),
     shared_shader!("ptcl"),


### PR DESCRIPTION
This just a collection of minor fixes to various things I noticed while looking over the code.

Adds a `Device::poll` call to the winit example.
Removes some lingering unnecessary `<f32>`s in the blit shaders.
Removes a duplicated bbox entry in the shared shader inclusion code and collapses nested `concat!`s.

Finally, it restores the computation of separated alpha in the output of fine which I removed in a previous PR. This allows the `render_to_texture` mode to be useful for generating images that can be properly blended over other content. The blit shader has been changed to accommodate this.