### PR TITLE
Read gradient data from info buffer in fine

### DIFF
--- a/piet-wgsl/shader/coarse.wgsl
+++ b/piet-wgsl/shader/coarse.wgsl
@@ -117,31 +117,12 @@ fn write_color(color: CmdColor) {
 // could just write an info offset and have fine bind that buffer and read
 // from it.
 
-fn write_lin_grad(lin: CmdLinGrad) {
-    alloc_cmd(5u);
-    ptcl[cmd_offset] = CMD_LIN_GRAD;
-    ptcl[cmd_offset + 1u] = lin.index;
-    ptcl[cmd_offset + 2u] = bitcast<u32>(lin.line_x);
-    ptcl[cmd_offset + 3u] = bitcast<u32>(lin.line_y);
-    ptcl[cmd_offset + 4u] = bitcast<u32>(lin.line_c);
-    cmd_offset += 5u;
-}
-
-fn write_rad_grad(rad: CmdRadGrad) {
-    alloc_cmd(12u);
-    ptcl[cmd_offset] = CMD_RAD_GRAD;
-    ptcl[cmd_offset + 1u] = rad.index;
-    ptcl[cmd_offset + 2u] = bitcast<u32>(rad.matrx.x);
-    ptcl[cmd_offset + 3u] = bitcast<u32>(rad.matrx.y);
-    ptcl[cmd_offset + 4u] = bitcast<u32>(rad.matrx.z);
-    ptcl[cmd_offset + 5u] = bitcast<u32>(rad.matrx.w);
-    ptcl[cmd_offset + 6u] = bitcast<u32>(rad.xlat.x);
-    ptcl[cmd_offset + 7u] = bitcast<u32>(rad.xlat.y);
-    ptcl[cmd_offset + 8u] = bitcast<u32>(rad.c1.x);
-    ptcl[cmd_offset + 9u] = bitcast<u32>(rad.c1.y);
-    ptcl[cmd_offset + 10u] = bitcast<u32>(rad.ra);
-    ptcl[cmd_offset + 11u] = bitcast<u32>(rad.roff);
-    cmd_offset += 12u;
+fn write_grad(ty: u32, index: u32, info_offset: u32) {
+    alloc_cmd(3u);
+    ptcl[cmd_offset] = ty;
+    ptcl[cmd_offset + 1u] = index;
+    ptcl[cmd_offset + 2u] = info_offset;
+    cmd_offset += 3u;
 }
 
 fn write_begin_clip() {
@@ -358,29 +339,17 @@ fn main(
                     case 0x114u: {
                         let linewidth = bitcast<f32>(info[di]);
                         write_path(tile, linewidth);
-                        var lin: CmdLinGrad;
-                        lin.index = scene[dd];
-                        lin.line_x = bitcast<f32>(info[di + 1u]);
-                        lin.line_y = bitcast<f32>(info[di + 2u]);
-                        lin.line_c = bitcast<f32>(info[di + 3u]);
-                        write_lin_grad(lin);
+                        let index = scene[dd];
+                        let info_offset = di + 1u;
+                        write_grad(CMD_LIN_GRAD, index, info_offset);
                     }
                     // DRAWTAG_FILL_RAD_GRADIENT
                     case 0x2dcu: {
                         let linewidth = bitcast<f32>(info[di]);
                         write_path(tile, linewidth);
-                        var rad: CmdRadGrad;
-                        rad.index = scene[dd];
-                        let m0 = bitcast<f32>(info[di + 1u]);
-                        let m1 = bitcast<f32>(info[di + 2u]);
-                        let m2 = bitcast<f32>(info[di + 3u]);
-                        let m3 = bitcast<f32>(info[di + 4u]);
-                        rad.matrx = vec4(m0, m1, m2, m3);
-                        rad.xlat = vec2(bitcast<f32>(info[di + 5u]), bitcast<f32>(info[di + 6u]));
-                        rad.c1 = vec2(bitcast<f32>(info[di + 7u]), bitcast<f32>(info[di + 8u]));
-                        rad.ra = bitcast<f32>(info[di + 9u]);
-                        rad.roff = bitcast<f32>(info[di + 10u]);
-                        write_rad_grad(rad);
+                        let index = scene[dd];
+                        let info_offset = di + 1u;
+                        write_grad(CMD_RAD_GRAD, index, info_offset);
                     }
                     // DRAWTAG_BEGIN_CLIP
                     case 0x05u: {

--- a/piet-wgsl/shader/coarse.wgsl
+++ b/piet-wgsl/shader/coarse.wgsl
@@ -113,10 +113,6 @@ fn write_color(color: CmdColor) {
     cmd_offset += 2u;
 }
 
-// Discussion point: these are basically copying from info to ptcl. We
-// could just write an info offset and have fine bind that buffer and read
-// from it.
-
 fn write_grad(ty: u32, index: u32, info_offset: u32) {
     alloc_cmd(3u);
     ptcl[cmd_offset] = ty;

--- a/piet-wgsl/shader/fine.wgsl
+++ b/piet-wgsl/shader/fine.wgsl
@@ -38,6 +38,9 @@ var<storage> ptcl: array<u32>;
 @group(0) @binding(5)
 var gradients: texture_2d<f32>;
 
+@group(0) @binding(6)
+var<storage> info: array<u32>;
+
 fn read_fill(cmd_ix: u32) -> CmdFill {
     let tile = ptcl[cmd_ix + 1u];
     let backdrop = i32(ptcl[cmd_ix + 2u]);
@@ -57,23 +60,25 @@ fn read_color(cmd_ix: u32) -> CmdColor {
 
 fn read_lin_grad(cmd_ix: u32) -> CmdLinGrad {
     let index = ptcl[cmd_ix + 1u];
-    let line_x = bitcast<f32>(ptcl[cmd_ix + 2u]);
-    let line_y = bitcast<f32>(ptcl[cmd_ix + 3u]);
-    let line_c = bitcast<f32>(ptcl[cmd_ix + 4u]);
+    let info_offset = ptcl[cmd_ix + 2u];
+    let line_x = bitcast<f32>(info[info_offset]);
+    let line_y = bitcast<f32>(info[info_offset + 1u]);
+    let line_c = bitcast<f32>(info[info_offset + 2u]);
     return CmdLinGrad(index, line_x, line_y, line_c);
 }
 
 fn read_rad_grad(cmd_ix: u32) -> CmdRadGrad {
     let index = ptcl[cmd_ix + 1u];
-    let m0 = bitcast<f32>(ptcl[cmd_ix + 2u]);
-    let m1 = bitcast<f32>(ptcl[cmd_ix + 3u]);
-    let m2 = bitcast<f32>(ptcl[cmd_ix + 4u]);
-    let m3 = bitcast<f32>(ptcl[cmd_ix + 5u]);
+    let info_offset = ptcl[cmd_ix + 2u];
+    let m0 = bitcast<f32>(info[info_offset]);
+    let m1 = bitcast<f32>(info[info_offset + 1u]);
+    let m2 = bitcast<f32>(info[info_offset + 2u]);
+    let m3 = bitcast<f32>(info[info_offset + 3u]);
     let matrx = vec4(m0, m1, m2, m3);
-    let xlat = vec2(bitcast<f32>(ptcl[cmd_ix + 6u]), bitcast<f32>(ptcl[cmd_ix + 7u]));
-    let c1 = vec2(bitcast<f32>(ptcl[cmd_ix + 8u]), bitcast<f32>(ptcl[cmd_ix + 9u]));
-    let ra = bitcast<f32>(ptcl[cmd_ix + 10u]);
-    let roff = bitcast<f32>(ptcl[cmd_ix + 11u]);
+    let xlat = vec2(bitcast<f32>(info[info_offset + 4u]), bitcast<f32>(info[info_offset + 5u]));
+    let c1 = vec2(bitcast<f32>(info[info_offset + 6u]), bitcast<f32>(info[info_offset + 7u]));
+    let ra = bitcast<f32>(info[info_offset + 8u]);
+    let roff = bitcast<f32>(info[info_offset + 9u]);
     return CmdRadGrad(index, matrx, xlat, c1, ra, roff);
 }
 
@@ -208,7 +213,7 @@ fn main(
                     let fg_i = fg * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                 }
-                cmd_ix += 2u;
+                cmd_ix += 3u;
             }
             // CMD_LIN_GRAD
             case 6u: {
@@ -221,7 +226,7 @@ fn main(
                     let fg_i = fg_rgba * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                 }
-                cmd_ix += 5u;
+                cmd_ix += 3u;
             }
             // CMD_RAD_GRAD
             case 7u: {
@@ -238,7 +243,7 @@ fn main(
                     let fg_i = fg_rgba * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                 }
-                cmd_ix += 12u;
+                cmd_ix += 3u;
             }
             // CMD_BEGIN_CLIP
             case 9u: {

--- a/piet-wgsl/shader/fine.wgsl
+++ b/piet-wgsl/shader/fine.wgsl
@@ -213,7 +213,7 @@ fn main(
                     let fg_i = fg * area[i];
                     rgba[i] = rgba[i] * (1.0 - fg_i.a) + fg_i;
                 }
-                cmd_ix += 3u;
+                cmd_ix += 2u;
             }
             // CMD_LIN_GRAD
             case 6u: {

--- a/piet-wgsl/src/render.rs
+++ b/piet-wgsl/src/render.rs
@@ -414,6 +414,7 @@ pub fn render_full(
             ResourceProxy::Image(out_image),
             ptcl_buf,
             gradient_image,
+            info_buf,
         ],
     );
     (recording, ResourceProxy::Image(out_image))

--- a/piet-wgsl/src/shaders.rs
+++ b/piet-wgsl/src/shaders.rs
@@ -290,6 +290,7 @@ pub fn full_shaders(device: &Device, engine: &mut Engine) -> Result<FullShaders,
             BindType::Image(ImageFormat::Rgba8),
             BindType::BufReadOnly,
             BindType::ImageRead(ImageFormat::Rgba8),
+            BindType::BufReadOnly,
         ],
     )?;
     Ok(FullShaders {


### PR DESCRIPTION
This changes coarse to write only index + info_offset into the ptcl for gradients. Per tile cost of gradients is reduced by 8 bytes and 36 bytes for linear and radial gradients respectively. We could save an additional 4 bytes per tile per gradient by copying the ramp index into the info buffer in draw_leaf but I'm not sure it's worth it.