### PR TITLE
Increase sizes of binning buffers

### DIFF
--- a/piet-wgsl/shader/binning.wgsl
+++ b/piet-wgsl/shader/binning.wgsl
@@ -62,6 +62,7 @@ fn main(
     for (var i = 0u; i < N_SLICE; i += 1u) {
         atomicStore(&sh_bitmaps[i][local_id.x], 0u);
     }
+    workgroupBarrier();
 
     // Read inputs and determine coverage of bins
     let element_ix = global_id.x;

--- a/piet-wgsl/src/render.rs
+++ b/piet-wgsl/src/render.rs
@@ -334,8 +334,7 @@ pub fn render_full(
     let bump_buf = BufProxy::new(BUMP_SIZE);
     let width_in_bins = (config.width_in_tiles + 15) / 16;
     let height_in_bins = (config.height_in_tiles + 15) / 16;
-    let n_bins = width_in_bins * height_in_bins;
-    let bin_header_buf = ResourceProxy::new_buf((n_bins * drawobj_wgs) as u64 * BIN_HEADER_SIZE);
+    let bin_header_buf = ResourceProxy::new_buf((256 * drawobj_wgs) as u64 * BIN_HEADER_SIZE);
     recording.clear_all(bump_buf);
     let bump_buf = ResourceProxy::Buf(bump_buf);
     recording.dispatch(
@@ -352,7 +351,10 @@ pub fn render_full(
             bin_header_buf,
         ],
     );
-    let path_buf = ResourceProxy::new_buf(n_path as u64 * PATH_SIZE);
+    // Note: this only needs to be rounded up because of the workaround to store the tile_offset
+    // in storage rather than workgroup memory.
+    let n_path_aligned = align_up(n_path as usize, 256);
+    let path_buf = ResourceProxy::new_buf(n_path_aligned as u64 * PATH_SIZE);
     let tile_buf = ResourceProxy::new_buf(1 << 20);
     let path_wgs = (n_path + shaders::PATH_BBOX_WG - 1) / shaders::PATH_BBOX_WG;
     recording.dispatch(


### PR DESCRIPTION
Increase the size of the bin header and path buffers to accommodate the actual extents accessed by the shaders.

Also add a missing workgroup barrier, not essential to fixing this bug but found while auditing the code.

Fixes #222